### PR TITLE
[fIx] 서버 인증 헤더 형식 변경 대응 인터셉터 작업 (#66)

### DIFF
--- a/android/app/src/main/java/com/teamtripdraw/android/di/RetrofitContainer.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/di/RetrofitContainer.kt
@@ -13,7 +13,6 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.util.concurrent.TimeUnit
 
-
 class RetrofitContainer(userIdentifyInfoDataSource: UserIdentifyInfoDataSource.Local) {
     private val authorizationInterceptor: Interceptor =
         Interceptor { chain ->
@@ -21,10 +20,7 @@ class RetrofitContainer(userIdentifyInfoDataSource: UserIdentifyInfoDataSource.L
                 proceed(
                     request()
                         .newBuilder()
-                        .addHeader(
-                            "Basic",
-                            AUTHORIZATION_INTERCEPTOR_VALUE_FORMAT.format(userIdentifyInfoDataSource.getIdentifyInfo())
-                        )
+                        .addHeader("Authorization", userIdentifyInfoDataSource.getIdentifyInfo())
                         .build()
                 )
             }
@@ -58,8 +54,4 @@ class RetrofitContainer(userIdentifyInfoDataSource: UserIdentifyInfoDataSource.L
             .addCallAdapterFactory(ResponseStateCallAdapterFactory())
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()
-
-    companion object {
-        private const val AUTHORIZATION_INTERCEPTOR_VALUE_FORMAT = "basic %s"
-    }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #66

### 📁 작업 설명

- 리오의 좌충우동 성장기(서버 헤더 형식 이상하게 해서 고침)


