### PR TITLE
[feat] 3차 데모데이를 위한 도메인 구현 (#79)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -8,6 +8,7 @@ import dev.tripdraw.domain.trip.Point;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private String address;
 
+    @Lob
     private String writing;
 
     @ManyToOne(fetch = LAZY)

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -31,15 +31,19 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(nullable = false)
+    private Long tripId;
+
     protected Post() {
     }
 
-    public Post(String title, Point point, String address, String writing, Member member) {
+    public Post(String title, Point point, String address, String writing, Member member, Long tripId) {
         this.title = title;
         this.point = point;
         this.address = address;
         this.writing = writing;
         this.member = member;
+        this.tripId = tripId;
     }
 
     public LocalDateTime pointRecordedAt() {
@@ -64,5 +68,9 @@ public class Post extends BaseEntity {
 
     public Member member() {
         return member;
+    }
+
+    public Long tripId() {
+        return tripId;
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -1,0 +1,68 @@
+package dev.tripdraw.domain.post;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import dev.tripdraw.domain.common.BaseEntity;
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.trip.Point;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+
+@Entity
+public class Post extends BaseEntity {
+
+    @Column(nullable = false)
+    private String title;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "point_id")
+    private Point point;
+
+    @Column(nullable = false)
+    private String address;
+
+    private String writing;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    protected Post() {
+    }
+
+    public Post(String title, Point point, String address, String writing, Member member) {
+        this.title = title;
+        this.point = point;
+        this.address = address;
+        this.writing = writing;
+        this.member = member;
+    }
+
+    public LocalDateTime pointRecordedAt() {
+        return point.recordedAt();
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public Point point() {
+        return point;
+    }
+
+    public String address() {
+        return address;
+    }
+
+    public String writing() {
+        return writing;
+    }
+
+    public Member member() {
+        return member;
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -6,6 +6,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import dev.tripdraw.domain.common.BaseEntity;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.exception.trip.TripException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
@@ -25,6 +26,7 @@ public class Trip extends BaseEntity {
     @Embedded
     private Route route = new Route();
 
+    @Column(nullable = false)
     private boolean isFinished = false;
 
     protected Trip() {

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -54,6 +54,10 @@ public class Trip extends BaseEntity {
         isFinished = true;
     }
 
+    public void changeName(String name) {
+        this.name.change(name);
+    }
+
     public TripName name() {
         return name;
     }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -15,8 +15,6 @@ import java.util.List;
 @Entity
 public class Trip extends BaseEntity {
 
-    private static final String TRIP_NAME_PREFIX = "의 여행";
-
     @Embedded
     private TripName name;
 
@@ -27,6 +25,8 @@ public class Trip extends BaseEntity {
     @Embedded
     private Route route = new Route();
 
+    private boolean isFinished = false;
+
     protected Trip() {
     }
 
@@ -36,7 +36,8 @@ public class Trip extends BaseEntity {
     }
 
     public static Trip from(Member member) {
-        return new Trip(TripName.from(member), member);
+        TripName tripName = TripName.from(member.nickname());
+        return new Trip(tripName, member);
     }
 
     public void add(Point point) {
@@ -47,6 +48,10 @@ public class Trip extends BaseEntity {
         if (!this.member.equals(member)) {
             throw new TripException(NOT_AUTHORIZED);
         }
+    }
+
+    public void finish() {
+        isFinished = true;
     }
 
     public TripName name() {
@@ -67,5 +72,9 @@ public class Trip extends BaseEntity {
 
     public List<Point> points() {
         return route.points();
+    }
+
+    public boolean isFinished() {
+        return isFinished;
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/TripName.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/TripName.java
@@ -12,12 +12,16 @@ public class TripName {
     protected TripName() {
     }
 
-    public TripName(String name) {
+    private TripName(String name) {
         this.name = name;
     }
 
     public static TripName from(String nickname) {
         return new TripName(nickname + TRIP_NAME_PREFIX);
+    }
+
+    public void change(String name) {
+        this.name = name;
     }
 
     public String name() {

--- a/backend/src/main/java/dev/tripdraw/domain/trip/TripName.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/TripName.java
@@ -1,6 +1,5 @@
 package dev.tripdraw.domain.trip;
 
-import dev.tripdraw.domain.member.Member;
 import jakarta.persistence.Embeddable;
 
 @Embeddable
@@ -17,8 +16,8 @@ public class TripName {
         this.name = name;
     }
 
-    public static TripName from(Member member) {
-        return new TripName(member.nickname() + TRIP_NAME_PREFIX);
+    public static TripName from(String nickname) {
+        return new TripName(nickname + TRIP_NAME_PREFIX);
     }
 
     public String name() {

--- a/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
@@ -19,7 +19,7 @@ class PostTest {
         LocalDateTime recordedAt = LocalDateTime.now();
         Point point = new Point(3.14, 5.25, recordedAt);
         Member member = new Member("통후추");
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member);
+        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member, 1L);
 
         // expect
         assertThat(post.pointRecordedAt()).isEqualTo(recordedAt);

--- a/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
@@ -1,0 +1,27 @@
+package dev.tripdraw.domain.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.trip.Point;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PostTest {
+
+    @Test
+    void 위치를_가져온다() {
+        // given
+        LocalDateTime recordedAt = LocalDateTime.now();
+        Point point = new Point(3.14, 5.25, recordedAt);
+        Member member = new Member("통후추");
+        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member);
+
+        // expect
+        assertThat(post.pointRecordedAt()).isEqualTo(recordedAt);
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripNameTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripNameTest.java
@@ -1,0 +1,24 @@
+package dev.tripdraw.domain.trip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TripNameTest {
+
+    @Test
+    void 이름을_변경한다() {
+        // given
+        TripName tripName = TripName.from("통후추");
+
+        // when
+        tripName.change("제주도 여행");
+        
+        // then
+        assertThat(tripName.name()).isEqualTo("제주도 여행");
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -65,7 +65,7 @@ class TripTest {
     }
 
     @Test
-    void 경로에_해당하는_모든_위치을_반환한다() {
+    void 경로에_해당하는_모든_위치를_반환한다() {
         // given
         Member member = new Member("통후추");
         Trip trip = Trip.from(member);
@@ -79,5 +79,18 @@ class TripTest {
 
         // then
         assertThat(result).containsExactly(point1, point2);
+    }
+
+    @Test
+    void 여행을_종료한다() {
+        // given
+        Member member = new Member("통후추");
+        Trip trip = Trip.from(member);
+
+        // when
+        trip.finish();
+
+        // then
+        assertThat(trip.isFinished()).isTrue();
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -58,10 +58,23 @@ class TripTest {
     void 이름을_반환한다() {
         // given
         Member member = new Member("통후추");
-        Trip trip = new Trip(new TripName("통후추의 여행"), member);
+        Trip trip = new Trip(TripName.from("통후추"), member);
 
         // expect
         assertThat(trip.nameValue()).isEqualTo("통후추의 여행");
+    }
+
+    @Test
+    void 이름을_변경한다() {
+        // given
+        Member member = new Member("통후추");
+        Trip trip = new Trip(TripName.from("통후추"), member);
+
+        // when
+        trip.changeName("제주도 여행");
+
+        // then
+        assertThat(trip.nameValue()).isEqualTo("제주도 여행");
     }
 
     @Test


### PR DESCRIPTION
### 📌 관련 이슈

- closed #79 

### 참고사항
몹 프로그래밍으로 구현해서 리뷰없이 머지

### 기능 설명
3차 데모데이를 위한 도메인 추가 및 변경

### 완료 태스크
- [x] Post 도메인 생성
- [x] Trip 도메인 변경
- [x] Point 도메인 변경

### Diagram
```mermaid
classDiagram
	Post --> Point

	class Post {
		Long tripId
	}
	class Point {
		boolean hasPost
	}
```