### PR TITLE
[feat] 여행 단일 조회 api 구현 및 여행 상태 필드(Enum) 추가 (#87)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -38,8 +38,7 @@ public class TripService {
 
     public PointResponse addPoint(LoginUser loginUser, PointCreateRequest pointCreateRequest) {
         Member member = getByNickname(loginUser.nickname());
-        Trip trip = tripRepository.findById(pointCreateRequest.tripId())
-                .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
+        Trip trip = getById(pointCreateRequest.tripId());
 
         Point point = pointCreateRequest.toPoint();
         trip.validateAuthorization(member);
@@ -52,5 +51,17 @@ public class TripService {
     private Member getByNickname(String nickname) {
         return memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+    }
+
+    private Trip getById(Long id) {
+        return tripRepository.findById(id)
+                .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
+    }
+
+    public TripResponse readById(LoginUser loginUser, Long id) {
+        Member member = getByNickname(loginUser.nickname());
+        Trip trip = getById(id);
+        trip.validateAuthorization(member);
+        return TripResponse.from(trip);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -38,7 +38,7 @@ public class TripService {
 
     public PointResponse addPoint(LoginUser loginUser, PointCreateRequest pointCreateRequest) {
         Member member = getByNickname(loginUser.nickname());
-        Trip trip = getById(pointCreateRequest.tripId());
+        Trip trip = getByTripId(pointCreateRequest.tripId());
 
         Point point = pointCreateRequest.toPoint();
         trip.validateAuthorization(member);
@@ -53,14 +53,14 @@ public class TripService {
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
     }
 
-    private Trip getById(Long id) {
-        return tripRepository.findById(id)
+    private Trip getByTripId(Long tripId) {
+        return tripRepository.findById(tripId)
                 .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
     }
 
     public TripResponse readTripById(LoginUser loginUser, Long id) {
         Member member = getByNickname(loginUser.nickname());
-        Trip trip = getById(id);
+        Trip trip = getByTripId(id);
         trip.validateAuthorization(member);
         return TripResponse.from(trip);
     }

--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -1,8 +1,5 @@
 package dev.tripdraw.application;
 
-import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
-import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
-
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.domain.trip.Point;
@@ -16,6 +13,9 @@ import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.trip.TripException;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 
 @Transactional
 @Service
@@ -58,7 +58,7 @@ public class TripService {
                 .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
     }
 
-    public TripResponse readById(LoginUser loginUser, Long id) {
+    public TripResponse readTripById(LoginUser loginUser, Long id) {
         Member member = getByNickname(loginUser.nickname());
         Trip trip = getById(id);
         trip.validateAuthorization(member);

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Status.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Status.java
@@ -1,0 +1,5 @@
+package dev.tripdraw.domain.trip;
+
+public enum Status {
+    ONGOING, FINISHED
+}

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -1,5 +1,7 @@
 package dev.tripdraw.domain.trip;
 
+import static dev.tripdraw.domain.trip.Status.FINISHED;
+import static dev.tripdraw.domain.trip.Status.ONGOING;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -35,20 +37,20 @@ public class Trip extends BaseEntity {
     private Route route = new Route();
 
     @Column(nullable = false)
-    private boolean isFinished;
+    private Status status;
 
     protected Trip() {
     }
 
     public Trip(TripName name, Member member) {
-        this(null, name, member, false);
+        this(null, name, member, ONGOING);
     }
 
-    public Trip(Long id, TripName name, Member member, boolean isFinished) {
+    public Trip(Long id, TripName name, Member member, Status status) {
         this.id = id;
         this.name = name;
         this.member = member;
-        this.isFinished = isFinished;
+        this.status = status;
     }
 
     public static Trip from(Member member) {
@@ -67,7 +69,7 @@ public class Trip extends BaseEntity {
     }
 
     public void finish() {
-        isFinished = true;
+        status = FINISHED;
     }
 
     public void changeName(String name) {
@@ -98,7 +100,7 @@ public class Trip extends BaseEntity {
         return route.points();
     }
 
-    public boolean isFinished() {
-        return isFinished;
+    public Status status() {
+        return status;
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.domain.trip;
 
-import static dev.tripdraw.domain.trip.Status.FINISHED;
-import static dev.tripdraw.domain.trip.Status.ONGOING;
+import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
+import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -37,7 +37,7 @@ public class Trip extends BaseEntity {
     private Route route = new Route();
 
     @Column(nullable = false)
-    private Status status;
+    private TripStatus status;
 
     protected Trip() {
     }
@@ -46,7 +46,7 @@ public class Trip extends BaseEntity {
         this(null, name, member, ONGOING);
     }
 
-    public Trip(Long id, TripName name, Member member, Status status) {
+    public Trip(Long id, TripName name, Member member, TripStatus status) {
         this.id = id;
         this.name = name;
         this.member = member;
@@ -100,7 +100,7 @@ public class Trip extends BaseEntity {
         return route.points();
     }
 
-    public Status status() {
+    public TripStatus status() {
         return status;
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/TripStatus.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/TripStatus.java
@@ -1,5 +1,5 @@
 package dev.tripdraw.domain.trip;
 
-public enum Status {
+public enum TripStatus {
     ONGOING, FINISHED
 }

--- a/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.dto.trip;
 
+import dev.tripdraw.domain.trip.Status;
 import dev.tripdraw.domain.trip.Trip;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -12,11 +13,14 @@ public record TripResponse(
         String name,
 
         @Schema(description = "경로")
-        List<PointResponse> routes
+        List<PointResponse> routes,
+
+        @Schema(description = "여행 상태", example = "ONGOING")
+        Status status
 ) {
 
     public static TripResponse from(Trip trip) {
-        return new TripResponse(trip.id(), trip.nameValue(), generateRoutes(trip));
+        return new TripResponse(trip.id(), trip.nameValue(), generateRoutes(trip), trip.status());
     }
 
     private static List<PointResponse> generateRoutes(Trip trip) {

--- a/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.dto.trip;
 
-import dev.tripdraw.domain.trip.Status;
 import dev.tripdraw.domain.trip.Trip;
+import dev.tripdraw.domain.trip.TripStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
@@ -16,7 +16,7 @@ public record TripResponse(
         List<PointResponse> routes,
 
         @Schema(description = "여행 상태", example = "ONGOING")
-        Status status
+        TripStatus status
 ) {
 
     public static TripResponse from(Trip trip) {

--- a/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
@@ -3,6 +3,7 @@ package dev.tripdraw.dto.trip;
 import dev.tripdraw.domain.trip.Trip;
 import dev.tripdraw.domain.trip.TripStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record TripResponse(
@@ -15,7 +16,7 @@ public record TripResponse(
         @Schema(description = "경로")
         List<PointResponse> routes,
 
-        @Schema(description = "여행 상태", example = "ONGOING")
+        @Schema(description = "여행 상태 (option : ONGOING, FINISHED)", example = "ONGOING")
         TripStatus status
 ) {
 

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
@@ -1,7 +1,5 @@
 package dev.tripdraw.presentation.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
 import dev.tripdraw.application.TripService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
 import dev.tripdraw.dto.auth.LoginUser;
@@ -13,11 +11,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
 
 @Tag(name = "Trip", description = "여행 관련 API 명세")
 @SwaggerAuthorizationRequired
@@ -62,7 +58,7 @@ public class TripController {
     )
     @GetMapping("/trips/{tripId}")
     public ResponseEntity<TripResponse> readById(@Auth LoginUser loginUser, @PathVariable Long tripId) {
-        TripResponse response = tripService.readById(loginUser, tripId);
+        TripResponse response = tripService.readTripById(loginUser, tripId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,5 +53,12 @@ public class TripController {
     ) {
         PointResponse response = tripService.addPoint(loginUser, pointCreateRequest);
         return ResponseEntity.status(CREATED).body(response);
+    }
+
+    @Operation(summary = "여행 조회 API", description = "단일 여행의 정보를 조회합니다.")
+    @GetMapping("/trips/{tripId}")
+    public ResponseEntity<TripResponse> readById(@Auth LoginUser loginUser, @PathVariable Long tripId) {
+        TripResponse response = tripService.readById(loginUser, tripId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
@@ -56,6 +56,10 @@ public class TripController {
     }
 
     @Operation(summary = "여행 조회 API", description = "단일 여행의 정보를 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "여행 조회 성공."
+    )
     @GetMapping("/trips/{tripId}")
     public ResponseEntity<TripResponse> readById(@Auth LoginUser loginUser, @PathVariable Long tripId) {
         TripResponse response = tripService.readById(loginUser, tripId);

--- a/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
@@ -1,9 +1,5 @@
 package dev.tripdraw.application;
 
-import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.dto.member.MemberCreateRequest;
@@ -12,6 +8,10 @@ import dev.tripdraw.exception.member.MemberException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ServiceTest
 class MemberServiceTest {
@@ -41,7 +41,7 @@ class MemberServiceTest {
     }
 
     @Test
-    void 이미_존재하는_닉네임으로_회원_가입시_예외를_발생시킨다() {
+    void 이미_존재하는_닉네임으로_회원_가입_시_예외를_발생시킨다() {
         // given
         MemberCreateRequest memberCreateRequest = new MemberCreateRequest("통후추");
 

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -88,7 +88,7 @@ class TripServiceTest {
     @Test
     void 여행을_ID로_조회한다() {
         // given & when
-        TripResponse tripResponse = tripService.readById(loginUser, trip.id());
+        TripResponse tripResponse = tripService.readTripById(loginUser, trip.id());
 
         // then
         assertSoftly(softly -> {

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.application;
 
-import static dev.tripdraw.domain.trip.Status.ONGOING;
+import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -83,4 +83,18 @@ class TripServiceTest {
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void trip_id로_여행을_조회한다() {
+        // given & when
+        TripResponse tripResponse = tripService.readById(loginUser, trip.id());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(tripResponse.tripId()).isNotNull();
+            softly.assertThat(tripResponse.name()).isNotNull();
+            softly.assertThat(tripResponse.routes()).isNotNull();
+            softly.assertThat(tripResponse.status()).isNotNull();
+        });
+    }
 }

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -1,10 +1,5 @@
 package dev.tripdraw.application;
 
-import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
-import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.domain.trip.Trip;
@@ -14,10 +9,16 @@ import dev.tripdraw.dto.trip.PointCreateRequest;
 import dev.tripdraw.dto.trip.PointResponse;
 import dev.tripdraw.dto.trip.TripResponse;
 import dev.tripdraw.exception.trip.TripException;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
+import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @ServiceTest
 class TripServiceTest {
@@ -85,7 +86,7 @@ class TripServiceTest {
     }
 
     @Test
-    void trip_id로_여행을_조회한다() {
+    void 여행을_ID로_조회한다() {
         // given & when
         TripResponse tripResponse = tripService.readById(loginUser, trip.id());
 

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.application;
 
+import static dev.tripdraw.domain.trip.Status.ONGOING;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -50,6 +51,7 @@ class TripServiceTest {
             softly.assertThat(tripResponse.tripId()).isNotNull();
             softly.assertThat(tripResponse.name()).isNotNull();
             softly.assertThat(tripResponse.routes()).isEmpty();
+            softly.assertThat(tripResponse.status()).isEqualTo(ONGOING);
         });
     }
 

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.domain.trip;
 
+import static dev.tripdraw.domain.trip.Status.FINISHED;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -104,6 +105,6 @@ class TripTest {
         trip.finish();
 
         // then
-        assertThat(trip.isFinished()).isTrue();
+        assertThat(trip.status()).isEqualTo(FINISHED);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.domain.trip;
 
-import static dev.tripdraw.domain.trip.Status.FINISHED;
+import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
@@ -1,9 +1,5 @@
 package dev.tripdraw.presentation.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CREATED;
-
 import dev.tripdraw.dto.member.MemberCreateRequest;
 import dev.tripdraw.dto.member.MemberResponse;
 import io.restassured.RestAssured;
@@ -15,6 +11,10 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -48,7 +48,7 @@ class MemberControllerTest extends ControllerTest {
     }
 
     @Test
-    void 회원가입시_닉네임에_공백이_있으면_예외를_발생시킨다() {
+    void 회원가입_시_닉네임에_공백이_있으면_예외를_발생시킨다() {
         // given
         MemberCreateRequest invalidRequest = new MemberCreateRequest("통 후추");
 

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.presentation.controller;
 
+import static dev.tripdraw.domain.trip.Status.ONGOING;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
@@ -62,6 +63,7 @@ class TripControllerTest extends ControllerTest {
             softly.assertThat(tripResponse.tripId()).isNotNull();
             softly.assertThat(tripResponse.name()).isNotNull();
             softly.assertThat(tripResponse.routes()).isEmpty();
+            softly.assertThat(tripResponse.status()).isEqualTo(ONGOING);
         });
     }
 

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.presentation.controller;
 
-import static dev.tripdraw.domain.trip.Status.ONGOING;
+import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -1,11 +1,5 @@
 package dev.tripdraw.presentation.controller;
 
-import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.OK;
-
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.domain.trip.Trip;
@@ -16,13 +10,18 @@ import dev.tripdraw.dto.trip.TripResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+
+import java.time.LocalDateTime;
+
+import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.HttpStatus.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -69,7 +68,7 @@ class TripControllerTest extends ControllerTest {
     }
 
     @Test
-    void 여행_생성시_인증에_실패하면_예외를_발생시킨다() {
+    void 여행_생성_시_인증에_실패하면_예외를_발생시킨다() {
         // given & expect
         RestAssured.given().log().all()
                 .auth().preemptive().oauth2(순후추_BASE64)
@@ -110,7 +109,7 @@ class TripControllerTest extends ControllerTest {
     }
 
     @Test
-    void 위치_정보_추가시_인증에_실패하면_예외를_발생시킨다() {
+    void 위치_정보_추가_시_인증에_실패하면_예외를_발생시킨다() {
         // given
         PointCreateRequest request = new PointCreateRequest(
                 trip.id(),
@@ -130,7 +129,7 @@ class TripControllerTest extends ControllerTest {
     }
 
     @Test
-    void trip_id로_여행을_조회한다() {
+    void 여행을_ID로_조회한다() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().preemptive().oauth2(통후추_BASE64)

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -4,6 +4,7 @@ import static dev.tripdraw.domain.trip.Status.ONGOING;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.OK;
 
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
@@ -127,5 +128,26 @@ class TripControllerTest extends ControllerTest {
                 .when().post("/points")
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
+    }
+
+    @Test
+    void trip_id로_여행을_조회한다() {
+        // given & when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .auth().preemptive().oauth2(통후추_BASE64)
+                .when().get("/trips/{tripId}", trip.id())
+                .then().log().all()
+                .extract();
+
+        // then
+        TripResponse tripResponse = response.as(TripResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softly.assertThat(tripResponse.tripId()).isNotNull();
+            softly.assertThat(tripResponse.name()).isNotNull();
+            softly.assertThat(tripResponse.routes()).isNotNull();
+            softly.assertThat(tripResponse.status()).isNotNull();
+        });
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #87 

### 📁 작업 설명

- 여행 단일 조회 api 및 테스트 추가했습니다.
- 여행 상태 관련 Enum Status 구현했습니다. (ONGOING, FINISHED)
- 여행에 상태를 나타내는 필드 Status status 추가했습니다.