### PR TITLE
[feat] 감상 생성 API 구현 (#72)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -11,7 +11,7 @@ import dev.tripdraw.domain.trip.Point;
 import dev.tripdraw.domain.trip.Trip;
 import dev.tripdraw.domain.trip.TripRepository;
 import dev.tripdraw.dto.auth.LoginUser;
-import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.exception.member.MemberException;
@@ -37,16 +37,16 @@ public class PostService {
         this.memberRepository = memberRepository;
     }
 
-    public PostResponse addAtCurrentPoint(LoginUser loginUser, PostPointCreateRequest postPointCreateRequest) {
+    public PostResponse addAtCurrentPoint(LoginUser loginUser, PostAndPointCreateRequest postAndPointCreateRequest) {
         Member member = findMemberByNickname(loginUser.nickname());
-        Trip trip = findTripById(postPointCreateRequest.tripId());
+        Trip trip = findTripById(postAndPointCreateRequest.tripId());
         trip.validateAuthorization(member);
 
-        Point point = postPointCreateRequest.toPoint();
+        Point point = postAndPointCreateRequest.toPoint();
         trip.add(point);
         tripRepository.flush();
 
-        Post post = postPointCreateRequest.toPost(member, point);
+        Post post = postAndPointCreateRequest.toPost(member, point);
         Post savedPost = postRepository.save(post);
         return PostResponse.from(savedPost);
     }

--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -37,19 +37,17 @@ public class PostService {
     }
 
     public PostResponse createOfCurrentLocation(LoginUser loginUser, PostPointCreateRequest postPointCreateRequest) {
-        // Trip 조회하고 loginUser의 소유가 맞는지 확인
         Member member = findMemberByNickname(loginUser.nickname());
         Long tripId = postPointCreateRequest.tripId();
         Trip trip = findTripById(tripId);
         trip.validateAuthorization(member);
-        // Point 생성 -> 연관관계 : Trip에 add 해주기 -> TripRepository save -> 저장 확인 필요
+
         Point point = postPointCreateRequest.toPoint();
         trip.add(point);
         tripRepository.flush();
-        // Post 생성 -> 연관관계 : Point 넣어주면 됨 -> PostRepository save -> 저장 확인 필요
+
         Post post = createPost(postPointCreateRequest, member, point);
         Post savedPost = postRepository.save(post);
-        // 반환
         return PostResponse.from(savedPost);
     }
 

--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -1,0 +1,78 @@
+package dev.tripdraw.application;
+
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
+
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.domain.post.Post;
+import dev.tripdraw.domain.post.PostRepository;
+import dev.tripdraw.domain.trip.Point;
+import dev.tripdraw.domain.trip.Trip;
+import dev.tripdraw.domain.trip.TripRepository;
+import dev.tripdraw.dto.auth.LoginUser;
+import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostResponse;
+import dev.tripdraw.exception.member.MemberException;
+import dev.tripdraw.exception.trip.TripException;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Transactional
+@Service
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final TripRepository tripRepository;
+    private final MemberRepository memberRepository;
+
+    public PostService(
+            PostRepository postRepository,
+            TripRepository tripRepository,
+            MemberRepository memberRepository
+    ) {
+        this.postRepository = postRepository;
+        this.tripRepository = tripRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    public PostResponse createOfCurrentLocation(LoginUser loginUser, PostPointCreateRequest postPointCreateRequest) {
+        // Trip 조회하고 loginUser의 소유가 맞는지 확인
+        Member member = findMemberByNickname(loginUser.nickname());
+        Long tripId = postPointCreateRequest.tripId();
+        Trip trip = findTripById(tripId);
+        trip.validateAuthorization(member);
+        // Point 생성 -> 연관관계 : Trip에 add 해주기 -> TripRepository save -> 저장 확인 필요
+        Point point = postPointCreateRequest.toPoint();
+        trip.add(point);
+        tripRepository.flush();
+        // Post 생성 -> 연관관계 : Point 넣어주면 됨 -> PostRepository save -> 저장 확인 필요
+        Post post = createPost(postPointCreateRequest, member, point);
+        Post savedPost = postRepository.save(post);
+        // 반환
+        return PostResponse.from(savedPost);
+    }
+
+    private Post createPost(PostPointCreateRequest postPointCreateRequest, Member member, Point point) {
+        Post post = new Post(
+                postPointCreateRequest.title(),
+                point,
+                postPointCreateRequest.address(),
+                postPointCreateRequest.writing(),
+                member,
+                postPointCreateRequest.tripId()
+        );
+        return post;
+    }
+
+    private Trip findTripById(Long tripId) {
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
+    }
+
+    private Member findMemberByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+    }
+}
+

--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -37,7 +37,7 @@ public class PostService {
         this.memberRepository = memberRepository;
     }
 
-    public PostResponse createOfCurrentLocation(LoginUser loginUser, PostPointCreateRequest postPointCreateRequest) {
+    public PostResponse addAtCurrentPoint(LoginUser loginUser, PostPointCreateRequest postPointCreateRequest) {
         Member member = findMemberByNickname(loginUser.nickname());
         Trip trip = findTripById(postPointCreateRequest.tripId());
         trip.validateAuthorization(member);
@@ -51,7 +51,7 @@ public class PostService {
         return PostResponse.from(savedPost);
     }
 
-    public PostResponse create(LoginUser loginUser, PostRequest postRequest) {
+    public PostResponse addAtExistingLocation(LoginUser loginUser, PostRequest postRequest) {
         Member member = findMemberByNickname(loginUser.nickname());
         Trip trip = findTripById(postRequest.tripId());
         trip.validateAuthorization(member);

--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
         trip.add(point);
         tripRepository.flush();
 
-        Post post = createPostOf(postPointCreateRequest, member, point);
+        Post post = postPointCreateRequest.toPost(member, point);
         Post savedPost = postRepository.save(post);
         return PostResponse.from(savedPost);
     }
@@ -57,34 +57,10 @@ public class PostService {
         trip.validateAuthorization(member);
 
         Point point = trip.findPointById(postRequest.pointId());
-        
-        Post post = createPostOf(postRequest, member, point);
+
+        Post post = postRequest.toPost(member, point);
         Post savedPost = postRepository.save(post);
         return PostResponse.from(savedPost);
-    }
-
-    private Post createPostOf(PostRequest postRequest, Member member, Point point) {
-        Post post = new Post(
-                postRequest.title(),
-                point,
-                postRequest.address(),
-                postRequest.writing(),
-                member,
-                postRequest.tripId()
-        );
-        return post;
-    }
-
-    private Post createPostOf(PostPointCreateRequest postPointCreateRequest, Member member, Point point) {
-        Post post = new Post(
-                postPointCreateRequest.title(),
-                point,
-                postPointCreateRequest.address(),
-                postPointCreateRequest.writing(),
-                member,
-                postPointCreateRequest.tripId()
-        );
-        return post;
     }
 
     private Trip findTripById(Long tripId) {

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -25,11 +25,10 @@ public class Post extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String title;
+    private Long tripId;
 
-    @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "point_id")
-    private Point point;
+    @Column(nullable = false)
+    private String title;
 
     @Column(nullable = false)
     private String address;
@@ -37,12 +36,13 @@ public class Post extends BaseEntity {
     @Lob
     private String writing;
 
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "point_id")
+    private Point point;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    @Column(nullable = false)
-    private Long tripId;
 
     protected Post() {
     }

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -1,6 +1,5 @@
 package dev.tripdraw.domain.post;
 
-import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -37,7 +36,7 @@ public class Post extends BaseEntity {
     @Lob
     private String writing;
 
-    @OneToOne(fetch = EAGER)
+    @OneToOne
     @JoinColumn(name = "point_id")
     private Point point;
 

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.domain.post;
 
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -36,7 +37,7 @@ public class Post extends BaseEntity {
     @Lob
     private String writing;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne(fetch = EAGER)
     @JoinColumn(name = "point_id")
     private Point point;
 

--- a/backend/src/main/java/dev/tripdraw/domain/post/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/PostRepository.java
@@ -1,0 +1,6 @@
+package dev.tripdraw.domain.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
@@ -26,7 +26,7 @@ public class Point extends BaseEntity {
     private Double longitude;
 
     @Column(nullable = false)
-    private boolean hasPost = false;
+    private boolean hasPost;
 
     @Column(nullable = false)
     private LocalDateTime recordedAt;
@@ -38,13 +38,14 @@ public class Point extends BaseEntity {
     }
 
     public Point(Double latitude, Double longitude, LocalDateTime recordedAt) {
-        this(null, latitude, longitude, recordedAt);
+        this(null, latitude, longitude, false, recordedAt);
     }
 
-    public Point(Long id, Double latitude, Double longitude, LocalDateTime recordedAt) {
+    public Point(Long id, Double latitude, Double longitude, boolean hasPost, LocalDateTime recordedAt) {
         this.id = id;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.hasPost = hasPost;
         this.recordedAt = recordedAt;
     }
 

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
@@ -26,6 +26,9 @@ public class Point extends BaseEntity {
     private Double longitude;
 
     @Column(nullable = false)
+    private boolean hasPost = false;
+
+    @Column(nullable = false)
     private LocalDateTime recordedAt;
 
     @Column(nullable = false)
@@ -67,6 +70,10 @@ public class Point extends BaseEntity {
 
     public Double longitude() {
         return longitude;
+    }
+
+    public boolean hasPost() {
+        return hasPost;
     }
 
     public LocalDateTime recordedAt() {

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -26,6 +27,13 @@ public class Route {
         points.add(point);
     }
 
+    public Point findPointById(Long pointIdToFind) {
+        return points.stream()
+                .filter(point -> point.id().equals(pointIdToFind))
+                .findAny()
+                .orElseThrow(() -> new TripException(POINT_NOT_FOUND));
+    }
+
     public List<Point> points() {
         return points;
     }
@@ -34,7 +42,7 @@ public class Route {
         Point pointToDelete = points.stream()
                 .filter(point -> Objects.equals(point.id(), pointId))
                 .findFirst()
-                .orElseThrow(() -> new TripException(POINT_NOT_FOUND));
+                .orElseThrow(() -> new TripException(POINT_NOT_IN_TRIP));
 
         pointToDelete.delete();
     }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
@@ -29,7 +29,7 @@ public class Route {
 
     public Point findPointById(Long pointIdToFind) {
         return points.stream()
-                .filter(point -> point.id().equals(pointIdToFind))
+                .filter(point -> Objects.equals(point.id(), pointIdToFind))
                 .findAny()
                 .orElseThrow(() -> new TripException(POINT_NOT_FOUND));
     }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -76,6 +76,10 @@ public class Trip extends BaseEntity {
         this.name.change(name);
     }
 
+    public Point findPointById(Long pointId) {
+        return route.findPointById(pointId);
+    }
+
     public Long id() {
         return id;
     }

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostAndPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostAndPointCreateRequest.java
@@ -18,7 +18,8 @@ public record PostAndPointCreateRequest(
         Long tripId,
 
         @Schema(description = "제목", example = "우도의 바닷가")
-        @NotBlank @Size(max = 100)
+        @NotBlank
+        @Size(max = 100)
         String title,
 
         @Schema(description = "현재 위치의 주소", example = "제주도 제주시 우도면")

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostAndPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostAndPointCreateRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
-public record PostPointCreateRequest(
+public record PostAndPointCreateRequest(
         @Schema(description = "감상이 속하는 여행의 Id", example = "1")
         @NotNull
         Long tripId,

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
@@ -1,6 +1,10 @@
 package dev.tripdraw.dto.post;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 import dev.tripdraw.domain.trip.Point;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record PostPointCreateRequest(
@@ -10,6 +14,8 @@ public record PostPointCreateRequest(
         String writing,
         Double latitude,
         Double longitude,
+        @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        @Schema(description = "yyyy-MM-dd'T'HH:mm:ss 형식")
         LocalDateTime recordedAt
 ) {
 

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
@@ -13,18 +13,30 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record PostPointCreateRequest(
+        @Schema(description = "감상이 속하는 여행의 Id", example = "1")
         @NotNull
         Long tripId,
+
+        @Schema(description = "제목", example = "우도의 바닷가")
         @NotBlank @Size(max = 100)
         String title,
+
+        @Schema(description = "현재 위치의 주소", example = "제주도 제주시 우도면")
         @NotBlank
         String address,
+
+        @Schema(description = "내용", example = "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.")
         @Size(max = 10_000)
         String writing,
+
+        @Schema(description = "현재 위치의 위도", example = "37.56663888630603")
         @NotNull
         Double latitude,
+
+        @Schema(description = "현재 위치의 경도", example = "126.97838310403904")
         @NotNull
         Double longitude,
+
         @NotNull
         @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         @Schema(description = "yyyy-MM-dd'T'HH:mm:ss 형식")

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
@@ -1,0 +1,19 @@
+package dev.tripdraw.dto.post;
+
+import dev.tripdraw.domain.trip.Point;
+import java.time.LocalDateTime;
+
+public record PostPointCreateRequest(
+        Long tripId,
+        String title,
+        String address,
+        String writing,
+        Double latitude,
+        Double longitude,
+        LocalDateTime recordedAt
+) {
+
+    public Point toPoint() {
+        return new Point(latitude, longitude, recordedAt);
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
@@ -3,6 +3,8 @@ package dev.tripdraw.dto.post;
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.post.Post;
 import dev.tripdraw.domain.trip.Point;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -31,5 +33,9 @@ public record PostPointCreateRequest(
 
     public Point toPoint() {
         return new Point(latitude, longitude, recordedAt);
+    }
+
+    public Post toPost(Member member, Point point) {
+        return new Post(title, point, address, writing, member, tripId);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostPointCreateRequest.java
@@ -5,15 +5,25 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dev.tripdraw.domain.trip.Point;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record PostPointCreateRequest(
+        @NotNull
         Long tripId,
+        @NotBlank @Size(max = 100)
         String title,
+        @NotBlank
         String address,
+        @Size(max = 10_000)
         String writing,
+        @NotNull
         Double latitude,
+        @NotNull
         Double longitude,
+        @NotNull
         @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         @Schema(description = "yyyy-MM-dd'T'HH:mm:ss 형식")
         LocalDateTime recordedAt

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostRequest.java
@@ -3,19 +3,29 @@ package dev.tripdraw.dto.post;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.post.Post;
 import dev.tripdraw.domain.trip.Point;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record PostRequest(
+        @Schema(description = "감상이 속하는 여행의 Id", example = "1")
         @NotNull
         Long tripId,
+
+        @Schema(description = "감상을 저장할 위치의 Id", example = "1")
         @NotNull
         Long pointId,
+
+        @Schema(description = "제목", example = "우도의 바닷가")
         @NotBlank @Size(max = 100)
         String title,
+
+        @Schema(description = "현재 위치의 주소", example = "제주도 제주시 우도면")
         @NotBlank
         String address,
+
+        @Schema(description = "내용", example = "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.")
         @Size(max = 10_000)
         String writing
 ) {

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostRequest.java
@@ -1,5 +1,8 @@
 package dev.tripdraw.dto.post;
 
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.post.Post;
+import dev.tripdraw.domain.trip.Point;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,4 +19,8 @@ public record PostRequest(
         @Size(max = 10_000)
         String writing
 ) {
+
+    public Post toPost(Member member, Point point) {
+        return new Post(title, point, address, writing, member, tripId);
+    }
 }

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostRequest.java
@@ -1,0 +1,19 @@
+package dev.tripdraw.dto.post;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PostRequest(
+        @NotNull
+        Long tripId,
+        @NotNull
+        Long pointId,
+        @NotBlank @Size(max = 100)
+        String title,
+        @NotBlank
+        String address,
+        @Size(max = 10_000)
+        String writing
+) {
+}

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostResponse.java
@@ -2,13 +2,25 @@ package dev.tripdraw.dto.post;
 
 import dev.tripdraw.domain.post.Post;
 import dev.tripdraw.dto.trip.PointResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record PostResponse(
+        @Schema(description = "감의 Id", example = "1")
         Long postId,
+
+        @Schema(description = "감상이 속하는 여행의 Id", example = "1")
         Long tripId,
+
+        @Schema(description = "제목", example = "우도의 바닷가")
         String title,
+
+        @Schema(description = "현재 위치의 주소", example = "제주도 제주시 우도면")
         String address,
+
+        @Schema(description = "내용", example = "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.")
         String writing,
+
+        @Schema(description = "감상이 저장된 위치 정보")
         PointResponse pointResponse
 ) {
 

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostResponse.java
@@ -1,0 +1,25 @@
+package dev.tripdraw.dto.post;
+
+import dev.tripdraw.domain.post.Post;
+import dev.tripdraw.dto.trip.PointResponse;
+
+public record PostResponse(
+        Long postId,
+        Long tripId,
+        String title,
+        String address,
+        String writing,
+        PointResponse pointResponse
+) {
+
+    public static PostResponse from(Post post) {
+        return new PostResponse(
+                post.id(),
+                post.tripId(),
+                post.title(),
+                post.address(),
+                post.writing(),
+                PointResponse.from(post.point())
+        );
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/dto/trip/PointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/PointCreateRequest.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record PointCreateRequest(
-        @Schema(description = "여행 Id", example = "1")
+        @Schema(description = "위치가 속하는 여행의 Id", example = "1")
         Long tripId,
 
         @Schema(description = "위도", example = "37.56663888630603")

--- a/backend/src/main/java/dev/tripdraw/dto/trip/PointResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/PointResponse.java
@@ -17,12 +17,15 @@ public record PointResponse(
         @Schema(description = "경도", example = "126.97838310403904")
         Double longitude,
 
+        @Schema(description = "감상 존재 여부", example = "false")
+        boolean hasPost,
+
         @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         @Schema(description = "yyyy-MM-dd'T'HH:mm:ss 형식", example = "2023-07-23T19:48:27", type = "string")
         LocalDateTime recordedAt
 ) {
 
     public static PointResponse from(Point point) {
-        return new PointResponse(point.id(), point.latitude(), point.longitude(), point.recordedAt());
+        return new PointResponse(point.id(), point.latitude(), point.longitude(), point.hasPost(), point.recordedAt());
     }
 }

--- a/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
@@ -10,8 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum TripExceptionType implements ExceptionType {
     TRIP_NOT_FOUND(NOT_FOUND, "존재하지 않는 여행입니다."),
     NOT_AUTHORIZED(FORBIDDEN, "해당 여행에 대한 접근 권한이 없습니다."),
-    POINT_NOT_FOUND(NOT_FOUND, "해당 여행에 존재하지 않는 위치정보입니다."),
+    POINT_NOT_IN_TRIP(NOT_FOUND, "해당 여행에 존재하지 않는 위치정보입니다."),
     POINT_ALREADY_DELETED(CONFLICT, "이미 삭제된 위치정보입니다."),
+    POINT_NOT_FOUND(NOT_FOUND, "존재하지 않는 위치입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -10,6 +10,7 @@ import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,7 +31,7 @@ public class PostController {
     @PostMapping("/posts/current-location")
     public ResponseEntity<PostResponse> createOfCurrentLocation(
             @Auth LoginUser loginUser,
-            @RequestBody PostPointCreateRequest postPointCreateRequest
+            @Valid @RequestBody PostPointCreateRequest postPointCreateRequest
     ) {
         PostResponse response = postService.createOfCurrentLocation(loginUser, postPointCreateRequest);
         return ResponseEntity.status(CREATED).body(response);

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -1,0 +1,38 @@
+package dev.tripdraw.presentation.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import dev.tripdraw.application.PostService;
+import dev.tripdraw.config.swagger.SwaggerLoginRequired;
+import dev.tripdraw.dto.auth.LoginUser;
+import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostResponse;
+import dev.tripdraw.presentation.member.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Post", description = "감상 관련 API 명세")
+@RestController
+public class PostController {
+
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @SwaggerLoginRequired
+    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상 생성")
+    @PostMapping("/posts/current-location")
+    public ResponseEntity<PostResponse> createOfCurrentLocation(
+            @Auth LoginUser loginUser,
+            @RequestBody PostPointCreateRequest postPointCreateRequest
+    ) {
+        PostResponse response = postService.createOfCurrentLocation(loginUser, postPointCreateRequest);
+        return ResponseEntity.status(CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -10,6 +10,7 @@ import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +30,10 @@ public class PostController {
     }
 
     @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상 생성")
+    @ApiResponse(
+            responseCode = "201",
+            description = "현재 위치에 대한 감상 생성 성공."
+    )
     @PostMapping("/posts/current-location")
     public ResponseEntity<PostResponse> createOfCurrentLocation(
             @Auth LoginUser loginUser,
@@ -39,6 +44,10 @@ public class PostController {
     }
 
     @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상 생성")
+    @ApiResponse(
+            responseCode = "201",
+            description = "사용자가 선택한 위치에 대한 감상 생성 성공."
+    )
     @PostMapping("/posts")
     public ResponseEntity<PostResponse> create(
             @Auth LoginUser loginUser,

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -3,7 +3,7 @@ package dev.tripdraw.presentation.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import dev.tripdraw.application.PostService;
-import dev.tripdraw.config.swagger.SwaggerLoginRequired;
+import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
 import dev.tripdraw.dto.auth.LoginUser;
 import dev.tripdraw.dto.post.PostPointCreateRequest;
 import dev.tripdraw.dto.post.PostRequest;
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Post", description = "감상 관련 API 명세")
+@SwaggerAuthorizationRequired
 @RestController
 public class PostController {
 
@@ -27,7 +28,6 @@ public class PostController {
         this.postService = postService;
     }
 
-    @SwaggerLoginRequired
     @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상 생성")
     @PostMapping("/posts/current-location")
     public ResponseEntity<PostResponse> createOfCurrentLocation(
@@ -38,7 +38,6 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @SwaggerLoginRequired
     @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상 생성")
     @PostMapping("/posts")
     public ResponseEntity<PostResponse> create(

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -39,7 +39,7 @@ public class PostController {
             @Auth LoginUser loginUser,
             @Valid @RequestBody PostPointCreateRequest postPointCreateRequest
     ) {
-        PostResponse response = postService.createOfCurrentLocation(loginUser, postPointCreateRequest);
+        PostResponse response = postService.addAtCurrentPoint(loginUser, postPointCreateRequest);
         return ResponseEntity.status(CREATED).body(response);
     }
 
@@ -53,7 +53,7 @@ public class PostController {
             @Auth LoginUser loginUser,
             @Valid @RequestBody PostRequest postRequest
     ) {
-        PostResponse response = postService.create(loginUser, postRequest);
+        PostResponse response = postService.addAtExistingLocation(loginUser, postRequest);
         return ResponseEntity.status(CREATED).body(response);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -6,6 +6,7 @@ import dev.tripdraw.application.PostService;
 import dev.tripdraw.config.swagger.SwaggerLoginRequired;
 import dev.tripdraw.dto.auth.LoginUser;
 import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +35,17 @@ public class PostController {
             @Valid @RequestBody PostPointCreateRequest postPointCreateRequest
     ) {
         PostResponse response = postService.createOfCurrentLocation(loginUser, postPointCreateRequest);
+        return ResponseEntity.status(CREATED).body(response);
+    }
+
+    @SwaggerLoginRequired
+    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상 생성")
+    @PostMapping("/posts")
+    public ResponseEntity<PostResponse> create(
+            @Auth LoginUser loginUser,
+            @Valid @RequestBody PostRequest postRequest
+    ) {
+        PostResponse response = postService.create(loginUser, postRequest);
         return ResponseEntity.status(CREATED).body(response);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -5,7 +5,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import dev.tripdraw.application.PostService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
 import dev.tripdraw.dto.auth.LoginUser;
-import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.presentation.member.Auth;
@@ -37,9 +37,9 @@ public class PostController {
     @PostMapping("/posts/current-location")
     public ResponseEntity<PostResponse> createOfCurrentLocation(
             @Auth LoginUser loginUser,
-            @Valid @RequestBody PostPointCreateRequest postPointCreateRequest
+            @Valid @RequestBody PostAndPointCreateRequest postAndPointCreateRequest
     ) {
-        PostResponse response = postService.addAtCurrentPoint(loginUser, postPointCreateRequest);
+        PostResponse response = postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest);
         return ResponseEntity.status(CREATED).body(response);
     }
 

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -52,7 +52,6 @@ class PostServiceTest {
         loginUser = new LoginUser("통후추");
     }
 
-
     @Test
     void 현재_위치에_대한_감상을_생성한다() {
         // given

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -66,7 +66,7 @@ class PostServiceTest {
         );
 
         // when
-        PostResponse postResponse = postService.createOfCurrentLocation(loginUser, postPointCreateRequest);
+        PostResponse postResponse = postService.addAtCurrentPoint(loginUser, postPointCreateRequest);
 
         // then
         assertSoftly(softly -> {
@@ -91,7 +91,7 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.createOfCurrentLocation(wrongUser, postPointCreateRequest))
+        assertThatThrownBy(() -> postService.addAtCurrentPoint(wrongUser, postPointCreateRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.getMessage());
     }
@@ -110,7 +110,7 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.createOfCurrentLocation(loginUser, requestOfNotExistedTripId))
+        assertThatThrownBy(() -> postService.addAtCurrentPoint(loginUser, requestOfNotExistedTripId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.getMessage());
     }
@@ -127,7 +127,7 @@ class PostServiceTest {
         );
 
         // when
-        PostResponse postResponse = postService.create(loginUser, postRequest);
+        PostResponse postResponse = postService.addAtExistingLocation(loginUser, postRequest);
 
         // then
         assertSoftly(softly -> {
@@ -150,7 +150,7 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.create(wrongUser, postRequest))
+        assertThatThrownBy(() -> postService.addAtExistingLocation(wrongUser, postRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.getMessage());
     }
@@ -167,7 +167,7 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.create(loginUser, requestOfNotExistedTripId))
+        assertThatThrownBy(() -> postService.addAtExistingLocation(loginUser, requestOfNotExistedTripId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.getMessage());
     }
@@ -184,7 +184,7 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.create(loginUser, requestOfNotExistedPointId))
+        assertThatThrownBy(() -> postService.addAtExistingLocation(loginUser, requestOfNotExistedPointId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_NOT_FOUND.getMessage());
     }

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -79,7 +79,7 @@ class PostServiceTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        LoginUser wrongUser = new LoginUser("상한 통후추");
+        LoginUser wrongUser = new LoginUser("상한후추");
         PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
@@ -100,7 +100,7 @@ class PostServiceTest {
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
         PostAndPointCreateRequest requestOfNotExistedTripId = new PostAndPointCreateRequest(
-                -1L,
+                Long.MIN_VALUE,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
@@ -140,7 +140,7 @@ class PostServiceTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        LoginUser wrongUser = new LoginUser("상한 통후추");
+        LoginUser wrongUser = new LoginUser("상한후추");
         PostRequest postRequest = new PostRequest(
                 trip.id(),
                 point.id(),
@@ -159,7 +159,7 @@ class PostServiceTest {
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
         PostRequest requestOfNotExistedTripId = new PostRequest(
-                -1L,
+                Long.MIN_VALUE,
                 point.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -177,7 +177,7 @@ class PostServiceTest {
         // given
         PostRequest requestOfNotExistedPointId = new PostRequest(
                 trip.id(),
-                -1L,
+                Long.MIN_VALUE,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -1,0 +1,114 @@
+package dev.tripdraw.application;
+
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.domain.post.PostRepository;
+import dev.tripdraw.domain.trip.Trip;
+import dev.tripdraw.domain.trip.TripRepository;
+import dev.tripdraw.dto.auth.LoginUser;
+import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostResponse;
+import dev.tripdraw.exception.member.MemberException;
+import dev.tripdraw.exception.trip.TripException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@ServiceTest
+class PostServiceTest {
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Trip trip;
+    private LoginUser loginUser;
+
+    @BeforeEach
+    void setUp() {
+        Member member = memberRepository.save(new Member("통후추"));
+        trip = tripRepository.save(Trip.from(member));
+        loginUser = new LoginUser("통후추");
+    }
+
+
+    // 정상 저장
+    @Test
+    void 현재_위치에_대한_감상을_생성한다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                trip.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // when
+        PostResponse postResponse = postService.createOfCurrentLocation(loginUser, postPointCreateRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(postResponse.postId()).isNotNull();
+            softly.assertThat(postResponse.title()).isEqualTo("우도의 바닷가");
+            softly.assertThat(postResponse.pointResponse().pointId()).isNotNull();
+        });
+    }
+
+    // nickname에 대한 Member 없을 때 예외
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
+        // given
+        LoginUser wrongUser = new LoginUser("상한 통후추");
+        PostPointCreateRequest requestOfNotExistedTripId = new PostPointCreateRequest(
+                trip.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        assertThatThrownBy(() -> postService.createOfCurrentLocation(wrongUser, requestOfNotExistedTripId))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
+    }
+
+    // tripId로 Trip 조회할 수 없을 때 예외
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
+        // given
+        PostPointCreateRequest requestOfNotExistedTripId = new PostPointCreateRequest(
+                -1L,
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        assertThatThrownBy(() -> postService.createOfCurrentLocation(loginUser, requestOfNotExistedTripId))
+                .isInstanceOf(TripException.class)
+                .hasMessage(TRIP_NOT_FOUND.getMessage());
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.application;
 
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -8,10 +9,12 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.domain.post.PostRepository;
+import dev.tripdraw.domain.trip.Point;
 import dev.tripdraw.domain.trip.Trip;
 import dev.tripdraw.domain.trip.TripRepository;
 import dev.tripdraw.dto.auth.LoginUser;
 import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.trip.TripException;
@@ -37,16 +40,19 @@ class PostServiceTest {
 
     private Trip trip;
     private LoginUser loginUser;
+    private Point point;
 
     @BeforeEach
     void setUp() {
         Member member = memberRepository.save(new Member("통후추"));
         trip = tripRepository.save(Trip.from(member));
+        point = new Point(1.1, 2.1, LocalDateTime.now());
+        trip.add(point);
+        tripRepository.flush();
         loginUser = new LoginUser("통후추");
     }
 
 
-    // 정상 저장
     @Test
     void 현재_위치에_대한_감상을_생성한다() {
         // given
@@ -71,12 +77,11 @@ class PostServiceTest {
         });
     }
 
-    // nickname에 대한 Member 없을 때 예외
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
         LoginUser wrongUser = new LoginUser("상한 통후추");
-        PostPointCreateRequest requestOfNotExistedTripId = new PostPointCreateRequest(
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -87,12 +92,11 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.createOfCurrentLocation(wrongUser, requestOfNotExistedTripId))
+        assertThatThrownBy(() -> postService.createOfCurrentLocation(wrongUser, postPointCreateRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.getMessage());
     }
 
-    // tripId로 Trip 조회할 수 없을 때 예외
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
@@ -110,5 +114,79 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.createOfCurrentLocation(loginUser, requestOfNotExistedTripId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 사용자가_선택한_위치에_대한_감상을_생성한다() {
+        // given
+        PostRequest postRequest = new PostRequest(
+                trip.id(),
+                point.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+        );
+
+        // when
+        PostResponse postResponse = postService.create(loginUser, postRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(postResponse.postId()).isNotNull();
+            softly.assertThat(postResponse.title()).isEqualTo("우도의 바닷가");
+            softly.assertThat(postResponse.pointResponse().pointId()).isNotNull();
+        });
+    }
+
+    @Test
+    void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
+        // given
+        LoginUser wrongUser = new LoginUser("상한 통후추");
+        PostRequest postRequest = new PostRequest(
+                trip.id(),
+                point.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+        );
+
+        // expect
+        assertThatThrownBy(() -> postService.create(wrongUser, postRequest))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
+        // given
+        PostRequest requestOfNotExistedTripId = new PostRequest(
+                -1L,
+                point.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+        );
+
+        // expect
+        assertThatThrownBy(() -> postService.create(loginUser, requestOfNotExistedTripId))
+                .isInstanceOf(TripException.class)
+                .hasMessage(TRIP_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_위치의_ID이면_예외를_발생시킨다() {
+        // given
+        PostRequest requestOfNotExistedPointId = new PostRequest(
+                trip.id(),
+                -1L,
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+        );
+
+        // expect
+        assertThatThrownBy(() -> postService.create(loginUser, requestOfNotExistedPointId))
+                .isInstanceOf(TripException.class)
+                .hasMessage(POINT_NOT_FOUND.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -13,7 +13,7 @@ import dev.tripdraw.domain.trip.Point;
 import dev.tripdraw.domain.trip.Trip;
 import dev.tripdraw.domain.trip.TripRepository;
 import dev.tripdraw.dto.auth.LoginUser;
-import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.exception.member.MemberException;
@@ -55,7 +55,7 @@ class PostServiceTest {
     @Test
     void 현재_위치에_대한_감상을_생성한다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -66,7 +66,7 @@ class PostServiceTest {
         );
 
         // when
-        PostResponse postResponse = postService.addAtCurrentPoint(loginUser, postPointCreateRequest);
+        PostResponse postResponse = postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest);
 
         // then
         assertSoftly(softly -> {
@@ -80,7 +80,7 @@ class PostServiceTest {
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
         LoginUser wrongUser = new LoginUser("상한 통후추");
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -91,7 +91,7 @@ class PostServiceTest {
         );
 
         // expect
-        assertThatThrownBy(() -> postService.addAtCurrentPoint(wrongUser, postPointCreateRequest))
+        assertThatThrownBy(() -> postService.addAtCurrentPoint(wrongUser, postAndPointCreateRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.getMessage());
     }
@@ -99,7 +99,7 @@ class PostServiceTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
-        PostPointCreateRequest requestOfNotExistedTripId = new PostPointCreateRequest(
+        PostAndPointCreateRequest requestOfNotExistedTripId = new PostAndPointCreateRequest(
                 -1L,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -146,7 +146,7 @@ class TripServiceTest {
         PointCreateRequest pointCreateRequest = new PointCreateRequest(trip.id(), 1.1, 2.2, LocalDateTime.now());
         tripService.addPoint(loginUser, pointCreateRequest);
 
-        Point inExistentPoint = new Point(Long.MAX_VALUE, 1.1, 2.2, LocalDateTime.now());
+        Point inExistentPoint = new Point(Long.MAX_VALUE, 1.1, 2.2, false, LocalDateTime.now());
         PointDeleteRequest pointDeleteRequest = new PointDeleteRequest(trip.id(), inExistentPoint.id());
 
         // expect

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -3,7 +3,7 @@ package dev.tripdraw.application;
 import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
-import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -122,7 +122,7 @@ class TripServiceTest {
                 .filter(point -> Objects.equals(point.id(), pointResponse.pointId()))
                 .findFirst()
                 .get();
-        
+
         assertThat(deletedPoint.isDeleted()).isTrue();
     }
 
@@ -152,7 +152,7 @@ class TripServiceTest {
         // expect
         assertThatThrownBy(() -> tripService.deletePoint(loginUser, pointDeleteRequest))
                 .isInstanceOf(TripException.class)
-                .hasMessage(POINT_NOT_FOUND.getMessage());
+                .hasMessage(POINT_NOT_IN_TRIP.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
@@ -2,6 +2,7 @@ package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,7 +33,7 @@ class RouteTest {
     void 경로에서_위치정보를_삭제한다() {
         // given
         Route route = new Route();
-        Point point = new Point(1L, 1.1, 2.2, LocalDateTime.now());
+        Point point = new Point(1L, 1.1, 2.2, false, LocalDateTime.now());
         route.add(point);
         Long id = point.id();
 
@@ -55,7 +56,7 @@ class RouteTest {
         // expect
         assertThatThrownBy(() -> route.deletePointById(inexistentPoint.id()))
                 .isInstanceOf(TripException.class)
-                .hasMessage(POINT_NOT_FOUND.getMessage());
+                .hasMessage(POINT_NOT_IN_TRIP.getMessage());
     }
 
     @Test
@@ -71,6 +72,35 @@ class RouteTest {
         assertThatThrownBy(() -> route.deletePointById(point.id()))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    void 위치를_ID로_조회한다() {
+        // given
+        Route route = new Route();
+        Point point1 = new Point(1L, 1.1, 2.1, false, LocalDateTime.now());
+        Point point2 = new Point(2L, 1.2, 2.2, false, LocalDateTime.now());
+        route.add(point1);
+        route.add(point2);
+
+        // when
+        Point foundPoint = route.findPointById(1L);
+
+        // then
+        assertThat(foundPoint).isEqualTo(point1);
+    }
+
+    @Test
+    void 위치를_존재하지_않는_ID로_조회하면_예외가_발생한다() {
+        // given
+        Route route = new Route();
+        Point point = new Point(1L, 1.1, 2.1, false, LocalDateTime.now());
+        route.add(point);
+
+        // expect
+        assertThatThrownBy(() -> route.findPointById(2L))
+                .isInstanceOf(TripException.class)
+                .hasMessage(POINT_NOT_FOUND.getMessage());
     }
 }
 

--- a/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
@@ -48,8 +48,8 @@ class RouteTest {
     void 경로에_존재하지_않는_위치정보를_삭제하면_예외를_발생시킨다() {
         // given
         Route route = new Route();
-        Point point = new Point(1L, 1.1, 2.2, LocalDateTime.now());
-        Point inexistentPoint = new Point(2L, 1.1, 2.2, LocalDateTime.now());
+        Point point = new Point(1L, 1.1, 2.2, false, LocalDateTime.now());
+        Point inexistentPoint = new Point(2L, 1.1, 2.2, false, LocalDateTime.now());
 
         route.add(point);
 
@@ -63,7 +63,7 @@ class RouteTest {
     void 이미_삭제된_위치정보를_삭제하면_예외를_발생시킨다() {
         // given
         Route route = new Route();
-        Point point = new Point(1L, 1.1, 2.2, LocalDateTime.now());
+        Point point = new Point(1L, 1.1, 2.2, false, LocalDateTime.now());
 
         route.add(point);
         route.deletePointById(point.id());

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -3,7 +3,7 @@ package dev.tripdraw.domain.trip;
 import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
-import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -155,6 +155,6 @@ class TripTest {
         // expect
         assertThatThrownBy(() -> trip.deletePointById(point2.id()))
                 .isInstanceOf(TripException.class)
-                .hasMessage(POINT_NOT_FOUND.getMessage());
+                .hasMessage(POINT_NOT_IN_TRIP.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -133,7 +133,7 @@ class TripTest {
         // given
         Member member = new Member("통후추");
         Trip trip = Trip.from(member);
-        Point point1 = new Point(1L, 1.1, 2.2, LocalDateTime.now());
+        Point point1 = new Point(1L, 1.1, 2.2, false, LocalDateTime.now());
         trip.add(point1);
         trip.deletePointById(point1.id());
 
@@ -148,8 +148,8 @@ class TripTest {
         // given
         Member member = new Member("통후추");
         Trip trip = Trip.from(member);
-        Point point1 = new Point(1L, 1.1, 2.2, LocalDateTime.now());
-        Point point2 = new Point(2L, 3.3, 4.4, LocalDateTime.now());
+        Point point1 = new Point(1L, 1.1, 2.2, false, LocalDateTime.now());
+        Point point2 = new Point(2L, 3.3, 4.4, false, LocalDateTime.now());
         trip.add(point1);
 
         // expect

--- a/backend/src/test/java/dev/tripdraw/dto/post/PostAndPointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/post/PostAndPointCreateRequestTest.java
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class PostPointCreateRequestTest {
+class PostAndPointCreateRequestTest {
 
     @Test
     void 위치_객체로_변환한다() {
         // given
-        PostPointCreateRequest request = new PostPointCreateRequest(
+        PostAndPointCreateRequest request = new PostAndPointCreateRequest(
                 1L,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",

--- a/backend/src/test/java/dev/tripdraw/dto/post/PostAndPointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/post/PostAndPointCreateRequestTest.java
@@ -28,10 +28,8 @@ class PostAndPointCreateRequestTest {
         Point point = request.toPoint();
 
         // then
-        assertThat(point).usingRecursiveComparison().isEqualTo(new Point(
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        ));
+        assertThat(point).usingRecursiveComparison().isEqualTo(
+                new Point(1.1, 2.2, LocalDateTime.of(2023, 7, 18, 20, 24))
+        );
     }
 }

--- a/backend/src/test/java/dev/tripdraw/dto/post/PostPointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/post/PostPointCreateRequestTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 class PostPointCreateRequestTest {
 
     @Test
-    void point_객체로_변환한다() {
+    void 위치_객체로_변환한다() {
         // given
         PostPointCreateRequest request = new PostPointCreateRequest(
                 1L,

--- a/backend/src/test/java/dev/tripdraw/dto/post/PostPointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/post/PostPointCreateRequestTest.java
@@ -1,23 +1,24 @@
-package dev.tripdraw.dto.request;
+package dev.tripdraw.dto.post;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tripdraw.domain.trip.Point;
-import dev.tripdraw.dto.trip.PointCreateRequest;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class PointCreateRequestTest {
+class PostPointCreateRequestTest {
 
     @Test
     void point_객체로_변환한다() {
         // given
-        PointCreateRequest request = new PointCreateRequest(
+        PostPointCreateRequest request = new PostPointCreateRequest(
                 1L,
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
                 1.1,
                 2.2,
                 LocalDateTime.of(2023, 7, 18, 20, 24)

--- a/backend/src/test/java/dev/tripdraw/dto/trip/PointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/trip/PointCreateRequestTest.java
@@ -26,10 +26,8 @@ class PointCreateRequestTest {
         Point point = request.toPoint();
 
         // then
-        assertThat(point).usingRecursiveComparison().isEqualTo(new Point(
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        ));
+        assertThat(point).usingRecursiveComparison().isEqualTo(
+                new Point(1.1, 2.2, LocalDateTime.of(2023, 7, 18, 20, 24))
+        );
     }
 }

--- a/backend/src/test/java/dev/tripdraw/dto/trip/PointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/trip/PointCreateRequestTest.java
@@ -1,0 +1,35 @@
+package dev.tripdraw.dto.trip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tripdraw.domain.trip.Point;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PointCreateRequestTest {
+
+    @Test
+    void point_객체로_변환한다() {
+        // given
+        PointCreateRequest request = new PointCreateRequest(
+                1L,
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // when
+        Point point = request.toPoint();
+
+        // then
+        assertThat(point).usingRecursiveComparison().isEqualTo(new Point(
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        ));
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/dto/trip/PointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/trip/PointCreateRequestTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 class PointCreateRequestTest {
 
     @Test
-    void point_객체로_변환한다() {
+    void 위치_객체로_변환한다() {
         // given
         PointCreateRequest request = new PointCreateRequest(
                 1L,

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -10,7 +10,7 @@ import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.domain.trip.Trip;
 import dev.tripdraw.domain.trip.TripRepository;
-import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.dto.trip.PointCreateRequest;
@@ -51,7 +51,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성한다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -65,7 +65,7 @@ class PostControllerTest extends ControllerTest {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", 통후추_BASE64)
-                .body(postPointCreateRequest)
+                .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .extract();
@@ -85,7 +85,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_인증에_실패하면_예외를_발생시킨다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -99,7 +99,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", 순후추_BASE64)
-                .body(postPointCreateRequest)
+                .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
@@ -108,7 +108,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 -1L,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -122,7 +122,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", 통후추_BASE64)
-                .body(postPointCreateRequest)
+                .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -131,7 +131,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_제목이_비어있으면_예외를_발생시킨다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -145,7 +145,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", 통후추_BASE64)
-                .body(postPointCreateRequest)
+                .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -154,7 +154,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_제목이_100자를_초과하면_예외를_발생시킨다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "a".repeat(101),
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -168,7 +168,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", 통후추_BASE64)
-                .body(postPointCreateRequest)
+                .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -177,7 +177,7 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_위도가_존재하지_않으면_예외를_발생시킨다() {
         // given
-        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -191,7 +191,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", 통후추_BASE64)
-                .body(postPointCreateRequest)
+                .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -29,8 +29,8 @@ import org.springframework.http.MediaType;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PostControllerTest extends ControllerTest {
 
-    private static final String 통후추_BASE64 = "Bearer 7Ya17ZuE7LaU";
-    private static final String 순후추_BASE64 = "Bearer 7Iic7ZuE7LaU";
+    private static final String 통후추_BASE64 = "7Ya17ZuE7LaU";
+    private static final String 순후추_BASE64 = "7Iic7ZuE7LaU";
 
     @Autowired
     private TripRepository tripRepository;
@@ -64,7 +64,7 @@ class PostControllerTest extends ControllerTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
@@ -98,7 +98,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 순후추_BASE64)
+                .auth().preemptive().oauth2(순후추_BASE64)
                 .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
@@ -121,7 +121,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
@@ -144,7 +144,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
@@ -167,7 +167,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
@@ -190,7 +190,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postAndPointCreateRequest)
                 .when().post("/posts/current-location")
                 .then().log().all()
@@ -213,7 +213,7 @@ class PostControllerTest extends ControllerTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -247,7 +247,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 순후추_BASE64)
+                .auth().preemptive().oauth2(순후추_BASE64)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -270,7 +270,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -291,7 +291,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -314,7 +314,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -337,7 +337,7 @@ class PostControllerTest extends ControllerTest {
         // expect
         RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(postRequest)
                 .when().post("/posts")
                 .then().log().all()
@@ -354,7 +354,7 @@ class PostControllerTest extends ControllerTest {
 
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", 통후추_BASE64)
+                .auth().preemptive().oauth2(통후추_BASE64)
                 .body(request)
                 .when().post("/points")
                 .then().log().all()

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -1,0 +1,126 @@
+package dev.tripdraw.presentation.controller;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.domain.trip.Trip;
+import dev.tripdraw.domain.trip.TripRepository;
+import dev.tripdraw.dto.post.PostPointCreateRequest;
+import dev.tripdraw.dto.post.PostResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PostControllerTest extends ControllerTest {
+
+    private static final String 통후추_BASE64 = "7Ya17ZuE7LaU";
+    private static final String 순후추_BASE64 = "7Iic7ZuE7LaU";
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Trip trip;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+
+        Member member = memberRepository.save(new Member("통후추"));
+        trip = tripRepository.save(Trip.from(member));
+    }
+
+    @Test
+    void 현재_위치에_대한_감상을_생성한다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                trip.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", 통후추_BASE64)
+                .body(postPointCreateRequest)
+                .when().post("/posts/current-location")
+                .then().log().all()
+                .extract();
+
+        // then
+        PostResponse postResponse = response.as(PostResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(CREATED.value());
+            softly.assertThat(postResponse.postId()).isNotNull();
+            softly.assertThat(postResponse.title()).isEqualTo("우도의 바닷가");
+            softly.assertThat(postResponse.pointResponse().pointId()).isNotNull();
+            softly.assertThat(postResponse.pointResponse().latitude()).isEqualTo(1.1);
+        });
+    }
+
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_인증에_실패하면_예외를_발생시킨다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                trip.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", 순후추_BASE64)
+                .body(postPointCreateRequest)
+                .when().post("/posts/current-location")
+                .then().log().all()
+                .statusCode(FORBIDDEN.value());
+    }
+
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                -1L,
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", 통후추_BASE64)
+                .body(postPointCreateRequest)
+                .when().post("/posts/current-location")
+                .then().log().all()
+                .statusCode(NOT_FOUND.value());
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -156,7 +156,7 @@ class PostControllerTest extends ControllerTest {
         // given
         PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
                 trip.id(),
-                "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 a",
+                "a".repeat(101),
                 "제주특별자치도 제주시 애월읍 소길리",
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
                 1.1,
@@ -329,7 +329,7 @@ class PostControllerTest extends ControllerTest {
         PostRequest postRequest = new PostRequest(
                 trip.id(),
                 pointResponse.pointId(),
-                "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 a",
+                "a".repeat(101),
                 "제주특별자치도 제주시 애월읍 소길리",
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.presentation.controller;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -122,5 +123,74 @@ class PostControllerTest extends ControllerTest {
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
+    }
+
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_제목이_비어있으면_예외를_발생시킨다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                trip.id(),
+                "",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", 통후추_BASE64)
+                .body(postPointCreateRequest)
+                .when().post("/posts/current-location")
+                .then().log().all()
+                .statusCode(BAD_REQUEST.value());
+    }
+
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_제목이_100자를_초과하면_예외를_발생시킨다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                trip.id(),
+                "123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 a",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.1,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", 통후추_BASE64)
+                .body(postPointCreateRequest)
+                .when().post("/posts/current-location")
+                .then().log().all()
+                .statusCode(BAD_REQUEST.value());
+    }
+
+    @Test
+    void 현재_위치에_대한_감상을_생성할_때_위도가_존재하지_않으면_예외를_발생시킨다() {
+        // given
+        PostPointCreateRequest postPointCreateRequest = new PostPointCreateRequest(
+                trip.id(),
+                "우도의 바닷가",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                null,
+                2.2,
+                LocalDateTime.of(2023, 7, 18, 20, 24)
+        );
+
+        // expect
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", 통후추_BASE64)
+                .body(postPointCreateRequest)
+                .when().post("/posts/current-location")
+                .then().log().all()
+                .statusCode(BAD_REQUEST.value());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -29,8 +29,8 @@ import org.springframework.http.MediaType;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PostControllerTest extends ControllerTest {
 
-    private static final String 통후추_BASE64 = "7Ya17ZuE7LaU";
-    private static final String 순후추_BASE64 = "7Iic7ZuE7LaU";
+    private static final String 통후추_BASE64 = "Bearer 7Ya17ZuE7LaU";
+    private static final String 순후추_BASE64 = "Bearer 7Iic7ZuE7LaU";
 
     @Autowired
     private TripRepository tripRepository;

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -109,7 +109,7 @@ class PostControllerTest extends ControllerTest {
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
         PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                -1L,
+                Long.MIN_VALUE,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
@@ -260,7 +260,7 @@ class PostControllerTest extends ControllerTest {
         PointResponse pointResponse = createPoint();
 
         PostRequest postRequest = new PostRequest(
-                -1L,
+                Long.MIN_VALUE,
                 pointResponse.pointId(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -282,7 +282,7 @@ class PostControllerTest extends ControllerTest {
         // given
         PostRequest postRequest = new PostRequest(
                 trip.id(),
-                -1L,
+                Long.MIN_VALUE,
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."


### PR DESCRIPTION
### 📌 관련 이슈

- closed #72 

### 📁 작업 설명

제목과 내용, 위치를 포함한 감상을 생성한다.
- 현재 위치에서 감상 생성 API 구현
- 사용자가 선택한 위치에서 감상 생성 API 구현

(* 사진 저장은 추후 추가 예정)

리뷰 부탁드립니다~
감사합니다!
