### PR TITLE
[feat] 회원 조회 기능 추가 (#105)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/MemberService.java
+++ b/backend/src/main/java/dev/tripdraw/application/MemberService.java
@@ -1,11 +1,13 @@
 package dev.tripdraw.application;
 
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
 
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.dto.member.MemberCreateRequest;
 import dev.tripdraw.dto.member.MemberCreateResponse;
+import dev.tripdraw.dto.member.MemberSearchResponse;
 import dev.tripdraw.exception.member.MemberException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,5 +35,11 @@ public class MemberService {
 
         Member member = memberRepository.save(new Member(nickname));
         return MemberCreateResponse.from(member);
+    }
+
+    public MemberSearchResponse findById(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        return MemberSearchResponse.from(member);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/config/AuthConfig.java
@@ -28,7 +28,7 @@ public class AuthConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .excludePathPatterns("/members")
+                .excludePathPatterns("/members/**")
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**");

--- a/backend/src/main/java/dev/tripdraw/dto/member/MemberSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/member/MemberSearchResponse.java
@@ -1,0 +1,17 @@
+package dev.tripdraw.dto.member;
+
+import dev.tripdraw.domain.member.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberSearchResponse(
+        @Schema(description = "사용자 Id", example = "1")
+        Long memberId,
+
+        @Schema(description = "닉네임", example = "통후추")
+        String nickname
+) {
+
+    public static MemberSearchResponse from(Member member) {
+        return new MemberSearchResponse(member.id(), member.nickname());
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/MemberController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/MemberController.java
@@ -5,11 +5,14 @@ import static org.springframework.http.HttpStatus.CREATED;
 import dev.tripdraw.application.MemberService;
 import dev.tripdraw.dto.member.MemberCreateRequest;
 import dev.tripdraw.dto.member.MemberCreateResponse;
+import dev.tripdraw.dto.member.MemberSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +38,16 @@ public class MemberController {
     public ResponseEntity<MemberCreateResponse> create(@Valid @RequestBody MemberCreateRequest memberCreateRequest) {
         MemberCreateResponse response = memberService.register(memberCreateRequest);
         return ResponseEntity.status(CREATED).body(response);
+    }
+
+    @Operation(summary = "사용자 조회 API", description = "사용자를 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "사용자 조회 성공."
+    )
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberSearchResponse> findById(@PathVariable Long memberId) {
+        MemberSearchResponse response = memberService.findById(memberId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.application;
 
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -7,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.dto.member.MemberCreateRequest;
-import dev.tripdraw.dto.member.MemberCreateResponse;
+import dev.tripdraw.dto.member.MemberSearchResponse;
 import dev.tripdraw.exception.member.MemberException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,9 +23,11 @@ class MemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    Member member;
+
     @BeforeEach
     void setUp() {
-        Member member = new Member("통후추");
+        member = new Member("통후추");
         memberRepository.save(member);
     }
 
@@ -34,7 +37,7 @@ class MemberServiceTest {
         MemberCreateRequest memberCreateRequest = new MemberCreateRequest("순후추");
 
         // when
-        MemberCreateResponse response = memberService.register(memberCreateRequest);
+        memberService.register(memberCreateRequest);
 
         // then
         assertThat(memberRepository.existsByNickname(memberCreateRequest.nickname())).isTrue();
@@ -49,5 +52,23 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.register(memberCreateRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(NICKNAME_CONFLICT.getMessage());
+    }
+
+    @Test
+    void 사용자를_조회한다() {
+        // expect
+        MemberSearchResponse result = memberService.findById(member.id());
+        assertThat(result.nickname()).isEqualTo("통후추");
+    }
+
+    @Test
+    void 존재하지_않는_사용자를_조회하는_경우_예외를_발생시킨다() {
+        // given
+        Long id = Long.MAX_VALUE;
+
+        // expect
+        assertThatThrownBy(() -> memberService.findById(id))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
@@ -92,7 +92,7 @@ class MemberControllerTest extends ControllerTest {
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/members/" + member.id())
+                .when().get("/members/{memberId}", member.id())
                 .then().log().all()
                 .statusCode(OK.value())
                 .extract();
@@ -107,7 +107,7 @@ class MemberControllerTest extends ControllerTest {
         // expect
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/members/" + Long.MAX_VALUE)
+                .when().get("/members/{memberId}", Long.MAX_VALUE)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value())
                 .extract();


### PR DESCRIPTION
### 📌 관련 이슈

- closed #105 

### 📁 작업 설명

- 사용자 조회 기능을 추가했습니다.
- 기존의 사용자 생성 시 닉네임을 반환했는데 클라이언트에서 보낸 값 보다 조금 더 안정된 값을 필요로 하는 것 같습니다.
- 사실 사용자를 Id로 조회하는 것은 애매한 느낌이 들지만 지금은 이대로 가고 다른 인증 방식을 사용할 때 수정해보는건 어떨까 싶습니다.