### PR TITLE
[feat] 여행 이름 수정 및 여행 종료 api 추가 (#114)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -14,6 +14,7 @@ import dev.tripdraw.dto.trip.PointCreateResponse;
 import dev.tripdraw.dto.trip.PointDeleteRequest;
 import dev.tripdraw.dto.trip.TripCreateResponse;
 import dev.tripdraw.dto.trip.TripResponse;
+import dev.tripdraw.dto.trip.TripUpdateRequest;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.trip.TripException;
 import jakarta.transaction.Transactional;
@@ -76,5 +77,14 @@ public class TripService {
         Trip trip = getByTripId(id);
         trip.validateAuthorization(member);
         return TripResponse.from(trip);
+    }
+
+    public void updateTripById(LoginUser loginUser, Long tripId, TripUpdateRequest tripUpdateRequest) {
+        Member member = getByNickname(loginUser.nickname());
+        Trip trip = getByTripId(tripId);
+        trip.validateAuthorization(member);
+
+        trip.changeName(tripUpdateRequest.name());
+        trip.changeStatus(tripUpdateRequest.status());
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -1,6 +1,5 @@
 package dev.tripdraw.domain.trip;
 
-import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static jakarta.persistence.FetchType.LAZY;
@@ -68,8 +67,8 @@ public class Trip extends BaseEntity {
         }
     }
 
-    public void finish() {
-        status = FINISHED;
+    public void changeStatus(TripStatus status) {
+        this.status = status;
     }
 
     public void changeName(String name) {

--- a/backend/src/main/java/dev/tripdraw/dto/trip/TripUpdateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/TripUpdateRequest.java
@@ -1,0 +1,13 @@
+package dev.tripdraw.dto.trip;
+
+import dev.tripdraw.domain.trip.TripStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TripUpdateRequest(
+        @Schema(description = "여행명", example = "통후추의 여행")
+        String name,
+
+        @Schema(description = "여행 상태 (option : ONGOING, FINISHED)", example = "ONGOING")
+        TripStatus status
+) {
+}

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
@@ -10,6 +10,7 @@ import dev.tripdraw.dto.trip.PointCreateResponse;
 import dev.tripdraw.dto.trip.PointDeleteRequest;
 import dev.tripdraw.dto.trip.TripCreateResponse;
 import dev.tripdraw.dto.trip.TripResponse;
+import dev.tripdraw.dto.trip.TripUpdateRequest;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,6 +82,18 @@ public class TripController {
             @RequestBody PointDeleteRequest pointDeleteRequest
     ) {
         tripService.deletePoint(loginUser, pointDeleteRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "여행 이름 수정 및 종료 API", description = "여행 이름을 수정하고, 여행을 종료합니다.")
+    @ApiResponse(
+            responseCode = "204",
+            description = "여행 이름 수정 및 종료 성공"
+    )
+    @PatchMapping("/trips/{tripId}")
+    public ResponseEntity<Void> update(@Auth LoginUser loginUser, @PathVariable Long tripId,
+                                       @RequestBody TripUpdateRequest tripUpdateRequest) {
+        tripService.updateTripById(loginUser, tripId, tripUpdateRequest);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.application;
 
+import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
@@ -19,6 +20,7 @@ import dev.tripdraw.dto.trip.PointCreateResponse;
 import dev.tripdraw.dto.trip.PointDeleteRequest;
 import dev.tripdraw.dto.trip.TripCreateResponse;
 import dev.tripdraw.dto.trip.TripResponse;
+import dev.tripdraw.dto.trip.TripUpdateRequest;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.trip.TripException;
 import java.time.LocalDateTime;
@@ -157,5 +159,20 @@ class TripServiceTest {
         assertThatThrownBy(() -> tripService.deletePoint(loginUser, pointDeleteRequest))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    void 여행의_이름과_상태를_수정한다() {
+        // given
+        TripUpdateRequest request = new TripUpdateRequest("제주도 여행", FINISHED);
+
+        // when
+        tripService.updateTripById(loginUser, trip.id(), request);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(trip.nameValue()).isEqualTo("제주도 여행");
+            softly.assertThat(trip.status()).isEqualTo(FINISHED);
+        });
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -1,6 +1,5 @@
 package dev.tripdraw.domain.trip;
 
-import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
@@ -15,6 +14,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -97,17 +98,18 @@ class TripTest {
         assertThat(result).containsExactly(point1, point2);
     }
 
-    @Test
-    void 여행을_종료한다() {
+    @ParameterizedTest
+    @CsvSource({"ONGOING, ONGOING", "FINISHED, FINISHED"})
+    void 여행_상태를_변경한다(TripStatus target, TripStatus expected) {
         // given
         Member member = new Member("통후추");
         Trip trip = Trip.from(member);
 
         // when
-        trip.finish();
+        trip.changeStatus(target);
 
         // then
-        assertThat(trip.status()).isEqualTo(FINISHED);
+        assertThat(trip.status()).isEqualTo(expected);
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -1,5 +1,7 @@
 package dev.tripdraw.presentation.controller;
 
+import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -18,6 +20,7 @@ import dev.tripdraw.dto.trip.PointDeleteRequest;
 import dev.tripdraw.dto.trip.PointResponse;
 import dev.tripdraw.dto.trip.TripCreateResponse;
 import dev.tripdraw.dto.trip.TripResponse;
+import dev.tripdraw.dto.trip.TripUpdateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -288,5 +291,23 @@ class TripControllerTest extends ControllerTest {
                 .when().delete("/points")
                 .then().log().all()
                 .statusCode(CONFLICT.value());
+    }
+
+    @Test
+    void 여행의_이름과_상태를_수정한다() {
+        // given
+        TripUpdateRequest tripUpdateRequest = new TripUpdateRequest("제주도 여행", FINISHED);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(통후추_BASE64)
+                .body(tripUpdateRequest)
+                .when().patch("/trips/{tripId}", trip.id())
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(NO_CONTENT.value());
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #114 

### 📁 작업 설명

- Trip 도메인 로직 수정
- TripService 여행 이름 수정 및 여행 상태 종료 로직 추가
- 여행 이름 수정 및 상태 종료 api 추가

### 작업 내용 상세 설명
- Trip 도메인 로직 수정
Trip.finish() 메서드를 아래와 같이 changeStatus()로 변경했습니다.

```java
public void finish() {
        status = FINISHED;
    }
```

```java
public void changeStatus(TripStatus status) {
        this.status = status;
    }
```

API의 body에서 넘어오는 status 필드를 사용하기 위해서입니다. 훗날 FINISHED -> ONGOING 등 다른 로직이 추가될 가능성을 염두에 두기도 했습니다.

```json
{
    "name": "제주도 여행",
    "status": "FINISHED"
}
```

해당 도메인 로직을 아래와 같이 테스트 했습니다. 지금껏 사용하지 않았던 형식(@ParameterizedTest)인지라, 컨벤션을 맞추면 좋을 것 같습니다. 다른 분들의 의견을 여쭤봅니다.
```java
    @ParameterizedTest
    @CsvSource({"ONGOING, ONGOING", "FINISHED, FINISHED"})
    void 여행_상태를_변경한다(TripStatus target, TripStatus expected) {
        // given
        Member member = new Member("통후추");
        Trip trip = Trip.from(member);

        // when
        trip.changeStatus(target);

        // then
        assertThat(trip.status()).isEqualTo(expected);
    }
```

### 참고사항
- patch 를 더 확장성있게 사용하는 방식은 추후 리팩터링하겠습니다.