### PR TITLE
[feat] 특정 여행의 모든 감상 조회 API 구현 (#74)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -18,6 +18,7 @@ import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostCreateResponse;
 import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
+import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.post.PostException;
 import dev.tripdraw.exception.trip.TripException;

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.domain.post;
 
-import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED;
+import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED_TO_POST;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -67,7 +67,7 @@ public class Post extends BaseEntity {
 
     public void validateAuthorization(Member member) {
         if (!this.member.equals(member)) {
-            throw new PostException(NOT_AUTHORIZED);
+            throw new PostException(NOT_AUTHORIZED_TO_POST);
         }
     }
 

--- a/backend/src/main/java/dev/tripdraw/domain/post/Post.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/Post.java
@@ -33,7 +33,7 @@ public class Post extends BaseEntity {
 
     @Column(nullable = false)
     private String address;
-    
+
     @Column(columnDefinition = "TEXT")
     private String writing;
 
@@ -55,6 +55,7 @@ public class Post extends BaseEntity {
     }
 
     public Post(Long id, String title, Point point, String address, String writing, Member member, Long tripId) {
+        point.registerPost();
         this.id = id;
         this.title = title;
         this.point = point;

--- a/backend/src/main/java/dev/tripdraw/domain/post/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/PostRepository.java
@@ -1,6 +1,9 @@
 package dev.tripdraw.domain.post;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findAllByTripId(Long tripId);
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_HAS_POST;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import dev.tripdraw.domain.common.BaseEntity;
@@ -51,6 +52,17 @@ public class Point extends BaseEntity {
 
     public Long id() {
         return id;
+    }
+
+    public void registerPost() {
+        validateNotPosted();
+        this.hasPost = true;
+    }
+
+    private void validateNotPosted() {
+        if (hasPost) {
+            throw new TripException(POINT_ALREADY_HAS_POST);
+        }
     }
 
     public void delete() {

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
-import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
+import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_INVALID_STATUS;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -66,7 +66,7 @@ public class Trip extends BaseEntity {
 
     public void validateAuthorization(Member member) {
         if (!this.member.equals(member)) {
-            throw new TripException(NOT_AUTHORIZED);
+            throw new TripException(NOT_AUTHORIZED_TO_TRIP);
         }
     }
 

--- a/backend/src/main/java/dev/tripdraw/dto/post/PostsResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/post/PostsResponse.java
@@ -1,0 +1,16 @@
+package dev.tripdraw.dto.post;
+
+import dev.tripdraw.domain.post.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record PostsResponse(
+        @Schema(description = "감상 목록")
+        List<PostResponse> posts
+) {
+    public static PostsResponse from(List<Post> posts) {
+        return new PostsResponse(posts.stream()
+                .map(PostResponse::from)
+                .toList());
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/exception/post/PostExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/post/PostExceptionType.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 
 public enum PostExceptionType implements ExceptionType {
     POST_NOT_FOUNT(NOT_FOUND, "존재하지 않는 감상입니다."),
-    NOT_AUTHORIZED(FORBIDDEN, "해당 감상에 대한 접근 권한이 없습니다.");
+    NOT_AUTHORIZED_TO_POST(FORBIDDEN, "해당 감상에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
@@ -15,6 +15,7 @@ public enum TripExceptionType implements ExceptionType {
     POINT_ALREADY_DELETED(CONFLICT, "이미 삭제된 위치정보입니다."),
     POINT_NOT_FOUND(NOT_FOUND, "존재하지 않는 위치입니다."),
     TRIP_INVALID_STATUS(BAD_REQUEST, "잘못된 여행 상태입니다."),
+    POINT_ALREADY_HAS_POST(CONFLICT, "이미 감상이 등록된 위치입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 
 public enum TripExceptionType implements ExceptionType {
     TRIP_NOT_FOUND(NOT_FOUND, "존재하지 않는 여행입니다."),
-    NOT_AUTHORIZED(FORBIDDEN, "해당 여행에 대한 접근 권한이 없습니다."),
+    NOT_AUTHORIZED_TO_TRIP(FORBIDDEN, "해당 여행에 대한 접근 권한이 없습니다."),
     POINT_NOT_IN_TRIP(NOT_FOUND, "해당 여행에 존재하지 않는 위치정보입니다."),
     POINT_ALREADY_DELETED(CONFLICT, "이미 삭제된 위치정보입니다."),
     POINT_NOT_FOUND(NOT_FOUND, "존재하지 않는 위치입니다."),

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -89,6 +89,6 @@ public class PostController {
             @PathVariable Long tripId
     ) {
         PostsResponse response = postService.readAllByTripId(loginUser, tripId);
-        return ResponseEntity.status(OK).body(response);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -9,6 +9,7 @@ import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostCreateResponse;
 import dev.tripdraw.dto.post.PostRequest;
 import dev.tripdraw.dto.post.PostResponse;
+import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -44,9 +45,6 @@ public class PostController {
             @Valid @RequestPart(value = "dto") PostAndPointCreateRequest postAndPointCreateRequest,
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
-        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-        System.out.println(postAndPointCreateRequest.title());
-        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>>>");
         PostCreateResponse response = postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, file);
         return ResponseEntity.status(CREATED).body(response);
     }
@@ -78,5 +76,19 @@ public class PostController {
     ) {
         PostResponse response = postService.read(loginUser, postId);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상 정보 조회")
+    @ApiResponse(
+            responseCode = "200",
+            description = "특정 여행의 모든 감상 조회 성공."
+    )
+    @GetMapping("/trips/{tripId}/posts")
+    public ResponseEntity<PostsResponse> readAllPostsOfTrip(
+            @Auth LoginUser loginUser,
+            @PathVariable Long tripId
+    ) {
+        PostsResponse response = postService.readAllByTripId(loginUser, tripId);
+        return ResponseEntity.status(OK).body(response);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.application;
 
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED;
 import static dev.tripdraw.exception.post.PostExceptionType.POST_NOT_FOUNT;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
@@ -21,7 +22,6 @@ import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.post.PostException;
-import dev.tripdraw.exception.post.PostExceptionType;
 import dev.tripdraw.exception.trip.TripException;
 import dev.tripdraw.exception.trip.TripExceptionType;
 import java.time.LocalDateTime;
@@ -217,7 +217,7 @@ class PostServiceTest {
     void 특정_감상을_조회할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
         PostCreateResponse postCreateResponse = createPost();
-        LoginUser wrongUser = new LoginUser("상한통후추");
+        LoginUser wrongUser = new LoginUser("상한후추");
 
         // expect
         assertThatThrownBy(() -> postService.read(wrongUser, postCreateResponse.postId()))
@@ -233,20 +233,19 @@ class PostServiceTest {
         // expect
         assertThatThrownBy(() -> postService.read(otherUser, postCreateResponse.postId()))
                 .isInstanceOf(PostException.class)
-                .hasMessage(PostExceptionType.NOT_AUTHORIZED.getMessage());
+                .hasMessage(NOT_AUTHORIZED.getMessage());
     }
 
     @Test
     void 특정_여행의_모든_감상을_조회한다() {
         // given
-        PostCreateResponse postCreateResponse1 = createPost();
-        PostCreateResponse postCreateResponse2 = createPost();
-
+        createPost();
+        createPost();
         // when
         PostsResponse postsResponse = postService.readAllByTripId(loginUser, trip.id());
-        List<PostResponse> posts = postsResponse.posts();
 
         // then
+        List<PostResponse> posts = postsResponse.posts();
         assertSoftly(softly -> {
             softly.assertThat(posts.get(0).postId()).isNotNull();
             softly.assertThat(posts.get(0).title()).isEqualTo("우도의 바닷가");
@@ -260,7 +259,7 @@ class PostServiceTest {
     @Test
     void 특정_여행의_모든_감상을_조회할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        LoginUser wrongUser = new LoginUser("상한 통후추");
+        LoginUser wrongUser = new LoginUser("상한후추");
 
         // expect
         assertThatThrownBy(() -> postService.readAllByTripId(wrongUser, trip.id()))

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -241,6 +241,7 @@ class PostServiceTest {
         // given
         createPost();
         createPost();
+
         // when
         PostsResponse postsResponse = postService.readAllByTripId(loginUser, trip.id());
 
@@ -276,7 +277,7 @@ class PostServiceTest {
     }
 
     @Test
-    void 특정_여행의_모든_감상을_조회할_때_로그인_한_사용자가_여행의_주인이_아니면_예외가_발생한() {
+    void 특정_여행의_모든_감상을_조회할_때_로그인_한_사용자가_여행의_주인이_아니면_예외가_발생한다() {
         // given & expect
         assertThatThrownBy(() -> postService.readAllByTripId(otherUser, trip.id()))
                 .isInstanceOf(TripException.class)

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -1,8 +1,9 @@
 package dev.tripdraw.application;
 
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
-import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED;
+import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED_TO_POST;
 import static dev.tripdraw.exception.post.PostExceptionType.POST_NOT_FOUNT;
+import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +24,6 @@ import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.post.PostException;
 import dev.tripdraw.exception.trip.TripException;
-import dev.tripdraw.exception.trip.TripExceptionType;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -233,7 +233,7 @@ class PostServiceTest {
         // expect
         assertThatThrownBy(() -> postService.read(otherUser, postCreateResponse.postId()))
                 .isInstanceOf(PostException.class)
-                .hasMessage(NOT_AUTHORIZED.getMessage());
+                .hasMessage(NOT_AUTHORIZED_TO_POST.getMessage());
     }
 
     @Test
@@ -280,7 +280,7 @@ class PostServiceTest {
         // given & expect
         assertThatThrownBy(() -> postService.readAllByTripId(otherUser, trip.id()))
                 .isInstanceOf(TripException.class)
-                .hasMessage(TripExceptionType.NOT_AUTHORIZED.getMessage());
+                .hasMessage(NOT_AUTHORIZED_TO_TRIP.getMessage());
     }
 
     private PostCreateResponse createPost() {

--- a/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.domain.post;
 
 import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_HAS_POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -8,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.trip.Point;
 import dev.tripdraw.exception.post.PostException;
+import dev.tripdraw.exception.trip.TripException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -53,5 +55,33 @@ class PostTest {
         assertThatThrownBy(() -> post.validateAuthorization(new Member("순후추")))
                 .isInstanceOf(PostException.class)
                 .hasMessage(NOT_AUTHORIZED.getMessage());
+    }
+
+    @Test
+    void 감상을_생성할_때_감상의_위치에_감상을_등록한다() {
+        // given
+        LocalDateTime recordedAt = LocalDateTime.now();
+        Point point = new Point(3.14, 5.25, recordedAt);
+        Member member = new Member("통후추");
+
+        // when
+        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member, 1L);
+
+        // then
+        assertThat(point.hasPost()).isTrue();
+    }
+
+    @Test
+    void 감상을_생성할_때_감상의_위치에_이미_감상이_등록되어_있다면_예외가_발생한다() {
+        // given
+        LocalDateTime recordedAt = LocalDateTime.now();
+        Point point = new Point(3.14, 5.25, recordedAt);
+        point.registerPost();
+        Member member = new Member("통후추");
+
+        // expect
+        assertThatThrownBy(() -> new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member, 1L))
+                .isInstanceOf(TripException.class)
+                .hasMessage(POINT_ALREADY_HAS_POST.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/post/PostTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.domain.post;
 
-import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED;
+import static dev.tripdraw.exception.post.PostExceptionType.NOT_AUTHORIZED_TO_POST;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_HAS_POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -54,7 +54,7 @@ class PostTest {
         // expect
         assertThatThrownBy(() -> post.validateAuthorization(new Member("순후추")))
                 .isInstanceOf(PostException.class)
-                .hasMessage(NOT_AUTHORIZED.getMessage());
+                .hasMessage(NOT_AUTHORIZED_TO_POST.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/domain/trip/PointTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/PointTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_HAS_POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -35,5 +36,29 @@ class PointTest {
         assertThatThrownBy(point::delete)
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    void 위치에_감상을_등록한다() {
+        // given
+        Point point = new Point();
+
+        // when
+        point.registerPost();
+
+        // then
+        assertThat(point.hasPost()).isTrue();
+    }
+
+    @Test
+    void 위치에_감상을_등록할_때_이미_감상이_등록되어_있으면_예외가_발생한다() {
+        // given
+        Point point = new Point();
+        point.registerPost();
+
+        // expect
+        assertThatThrownBy(point::registerPost)
+                .isInstanceOf(TripException.class)
+                .hasMessage(POINT_ALREADY_HAS_POST.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.domain.trip;
 
-import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED;
+import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_INVALID_STATUS;
@@ -56,7 +56,7 @@ class TripTest {
         // expect
         assertThatThrownBy(() -> trip.validateAuthorization(new Member("other")))
                 .isInstanceOf(TripException.class)
-                .hasMessage(NOT_AUTHORIZED.getMessage());
+                .hasMessage(NOT_AUTHORIZED_TO_TRIP.getMessage());
     }
 
     @Test
@@ -118,7 +118,7 @@ class TripTest {
         // given
         Member member = new Member("통후추");
         Trip trip = Trip.from(member);
-        
+
         // expect
         assertThatThrownBy(() -> trip.changeStatus(null))
                 .isInstanceOf(TripException.class)

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -67,11 +67,13 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
+
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .extract();
@@ -98,11 +100,13 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(순후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
@@ -121,11 +125,13 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -144,11 +150,13 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -167,11 +175,13 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -190,11 +200,13 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -213,11 +225,13 @@ class PostControllerTest extends ControllerTest {
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postRequest);
+
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts")
                 .then().log().all()
                 .extract();
@@ -244,11 +258,13 @@ class PostControllerTest extends ControllerTest {
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(순후추_BASE64)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
@@ -267,11 +283,13 @@ class PostControllerTest extends ControllerTest {
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -288,11 +306,13 @@ class PostControllerTest extends ControllerTest {
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -311,11 +331,13 @@ class PostControllerTest extends ControllerTest {
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -334,11 +356,13 @@ class PostControllerTest extends ControllerTest {
                 "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
         );
 
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postRequest);
+
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -397,8 +421,8 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 특정_여행에_대한_모든_감상을_조회한다() {
         // given
-        PostCreateResponse postResponse1 = createPost();
-        PostCreateResponse postResponse2 = createPost();
+        createPost();
+        createPost();
 
         // when
         ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
@@ -465,8 +489,6 @@ class PostControllerTest extends ControllerTest {
         return response.as(PointResponse.class);
     }
 
-    // TODO 해당 메서드 실행 시, @RequestPart(value = "dto") PostAndPointCreateRequest postAndPointCreateRequest 객체가 ?로 바인딩되는 오류 해결
-    // TODO 해당 메서드를 실행하는 조회 테스트 2개에 대해서 -> 내용 검증하는 assertion 추가하여 확인하기
     private PostCreateResponse createPost() {
         // given
         PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
@@ -479,12 +501,7 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
-        MultiPartSpecification multiPartSpecification = new MultiPartSpecBuilder(postAndPointCreateRequest)
-                .fileName("postAndPointCreateRequest")
-                .controlName("dto")
-                .charset("UTF-8")
-                .mimeType("application/json")
-                .build();
+        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postAndPointCreateRequest);
 
         ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
@@ -496,5 +513,14 @@ class PostControllerTest extends ControllerTest {
 
         PostCreateResponse postResponse = createResponse.as(PostCreateResponse.class);
         return postResponse;
+    }
+
+    private MultiPartSpecification getMultiPartSpecification(Object request) {
+        return new MultiPartSpecBuilder(request)
+                .fileName("postAndPointCreateRequest")
+                .controlName("dto")
+                .mimeType("application/json")
+                .charset("UTF-8")
+                .build();
     }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PostControllerTest extends ControllerTest {
@@ -401,7 +402,7 @@ class PostControllerTest extends ControllerTest {
         ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .when().get("/trips/" + trip.id() + "/posts")
+                .when().get("/trips/{tripId}/posts", trip.id())
                 .then().log().all()
                 .extract();
 
@@ -427,7 +428,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(순후추_BASE64)
-                .when().get("/trips/" + trip.id() + "/posts")
+                .when().get("/trips/{tripId}/posts", trip.id())
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
     }
@@ -438,7 +439,7 @@ class PostControllerTest extends ControllerTest {
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(순후추_BASE64)
-                .when().get("/trips/" + Long.MIN_VALUE + "/posts")
+                .when().get("/trips/{tripId}/posts", Long.MIN_VALUE)
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
     }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -16,6 +16,7 @@ import dev.tripdraw.domain.trip.TripRepository;
 import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostCreateResponse;
 import dev.tripdraw.dto.post.PostRequest;
+import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.dto.trip.PointCreateRequest;
 import dev.tripdraw.dto.trip.PointResponse;
@@ -340,31 +341,31 @@ class PostControllerTest extends ControllerTest {
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
     }
-//    TODO 해당 테스트에서, @RequestPart(value = "dto") PostAndPointCreateRequest postAndPointCreateRequest 객체가 ?로 바인딩되는 오류 해결
-//    @Test
-//    void 특정_감상을_조회한다() {
-//        // given
-//        PostCreateResponse postResponse = createPost();
-//
-//        // when
-//        ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
-//                .contentType(APPLICATION_JSON_VALUE)
-//                .auth().preemptive().oauth2(통후추_BASE64)
-//                .when().get("/posts/{postId}", postResponse.postId())
-//                .then().log().all()
-//                .extract();
-//
-//        PostResponse getResponse = findResponse.as(PostResponse.class);
-//
-//        // then
-//        assertSoftly(softly -> {
-//            softly.assertThat(findResponse.statusCode()).isEqualTo(OK.value());
-//            softly.assertThat(getResponse.postId()).isNotNull();
-//            softly.assertThat(getResponse.title()).isEqualTo("우도의 바닷가");
-//            softly.assertThat(getResponse.pointResponse().pointId()).isNotNull();
-//            softly.assertThat(getResponse.pointResponse().latitude()).isEqualTo(1.1);
-//        });
-//    }
+
+    @Test
+    void 특정_감상을_조회한다() {
+        // given
+        PostCreateResponse postResponse = createPost();
+
+        // when
+        ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(통후추_BASE64)
+                .when().get("/posts/{postId}", postResponse.postId())
+                .then().log().all()
+                .extract();
+
+        PostResponse getResponse = findResponse.as(PostResponse.class);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(findResponse.statusCode()).isEqualTo(OK.value());
+            softly.assertThat(getResponse.postId()).isNotNull();
+            softly.assertThat(getResponse.title()).isEqualTo("우도의 바닷가");
+            softly.assertThat(getResponse.pointResponse().pointId()).isNotNull();
+            softly.assertThat(getResponse.pointResponse().latitude()).isEqualTo(1.1);
+        });
+    }
 
     @Test
     void 특정_감상을_조회할_때_인증에_실패하면_예외가_발생한다() {
@@ -411,11 +412,9 @@ class PostControllerTest extends ControllerTest {
         assertSoftly(softly -> {
             softly.assertThat(findResponse.statusCode()).isEqualTo(OK.value());
             softly.assertThat(postsResponse.posts().get(0).postId()).isNotNull();
-            softly.assertThat(postsResponse.posts().get(0).title()).isEqualTo("우도의 바닷가");
             softly.assertThat(postsResponse.posts().get(0).pointResponse().pointId()).isNotNull();
             softly.assertThat(postsResponse.posts().get(0).pointResponse().latitude()).isEqualTo(1.1);
             softly.assertThat(postsResponse.posts().get(1).postId()).isNotNull();
-            softly.assertThat(postsResponse.posts().get(1).title()).isEqualTo("우도의 바닷가");
             softly.assertThat(postsResponse.posts().get(1).pointResponse().pointId()).isNotNull();
             softly.assertThat(postsResponse.posts().get(1).pointResponse().latitude()).isEqualTo(1.1);
         });
@@ -462,6 +461,8 @@ class PostControllerTest extends ControllerTest {
         return response.as(PointResponse.class);
     }
 
+    // TODO 해당 메서드 실행 시, @RequestPart(value = "dto") PostAndPointCreateRequest postAndPointCreateRequest 객체가 ?로 바인딩되는 오류 해결
+    // TODO 해당 메서드를 실행하는 조회 테스트 2개에 대해서 -> 내용 검증하는 assertion 추가하여 확인하기
     private PostCreateResponse createPost() {
         // given
         PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -21,8 +21,10 @@ import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.dto.trip.PointCreateRequest;
 import dev.tripdraw.dto.trip.PointResponse;
 import io.restassured.RestAssured;
+import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import io.restassured.specification.MultiPartSpecification;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -412,9 +414,11 @@ class PostControllerTest extends ControllerTest {
         assertSoftly(softly -> {
             softly.assertThat(findResponse.statusCode()).isEqualTo(OK.value());
             softly.assertThat(postsResponse.posts().get(0).postId()).isNotNull();
+            softly.assertThat(postsResponse.posts().get(0).title()).isEqualTo("우도의 바닷가");
             softly.assertThat(postsResponse.posts().get(0).pointResponse().pointId()).isNotNull();
             softly.assertThat(postsResponse.posts().get(0).pointResponse().latitude()).isEqualTo(1.1);
             softly.assertThat(postsResponse.posts().get(1).postId()).isNotNull();
+            softly.assertThat(postsResponse.posts().get(1).title()).isEqualTo("우도의 바닷가");
             softly.assertThat(postsResponse.posts().get(1).pointResponse().pointId()).isNotNull();
             softly.assertThat(postsResponse.posts().get(1).pointResponse().latitude()).isEqualTo(1.1);
         });
@@ -475,10 +479,17 @@ class PostControllerTest extends ControllerTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
+        MultiPartSpecification multiPartSpecification = new MultiPartSpecBuilder(postAndPointCreateRequest)
+                .fileName("postAndPointCreateRequest")
+                .controlName("dto")
+                .charset("UTF-8")
+                .mimeType("application/json")
+                .build();
+
         ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
                 .auth().preemptive().oauth2(통후추_BASE64)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .multiPart(multiPartSpecification)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .extract();

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/PostControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
@@ -15,7 +16,6 @@ import dev.tripdraw.domain.trip.TripRepository;
 import dev.tripdraw.dto.post.PostAndPointCreateRequest;
 import dev.tripdraw.dto.post.PostCreateResponse;
 import dev.tripdraw.dto.post.PostRequest;
-import dev.tripdraw.dto.post.PostResponse;
 import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.dto.trip.PointCreateRequest;
 import dev.tripdraw.dto.trip.PointResponse;
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PostControllerTest extends ControllerTest {


### PR DESCRIPTION
### 📌 관련 이슈

- closed #74
- closed #147 

### 📁 작업 설명

- 특정 여행의 모든 감상 조회 API 구현
- 감상 생성 시, 감상에 속한 위치의 hasPost 필드 true로 변경

작업 시간 탓에, 부득이 하게 2개의 issue를 한 번에 해결했습니다.
양해 부탁드립니다.

감사합니다!