### PR TITLE
[fix] 여행 단일 조회 필드명 routes에서 route로 변경 (#176)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/TripResponse.java
@@ -13,7 +13,7 @@ public record TripResponse(
         String name,
 
         @Schema(description = "경로")
-        List<PointResponse> routes,
+        List<PointResponse> route,
 
         @Schema(description = "여행 상태 (option : ONGOING, FINISHED)", example = "ONGOING")
         TripStatus status,
@@ -29,14 +29,14 @@ public record TripResponse(
         return new TripResponse(
                 trip.id(),
                 trip.nameValue(),
-                generateRoutes(trip),
+                generateRoute(trip),
                 trip.status(),
                 trip.imageUrl(),
                 trip.routeImageUrl()
         );
     }
 
-    private static List<PointResponse> generateRoutes(Trip trip) {
+    private static List<PointResponse> generateRoute(Trip trip) {
         return trip.points().stream()
                 .map(PointResponse::from)
                 .toList();

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -104,7 +104,7 @@ class TripServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(tripResponse.tripId()).isNotNull();
             softly.assertThat(tripResponse.name()).isNotNull();
-            softly.assertThat(tripResponse.routes()).isNotNull();
+            softly.assertThat(tripResponse.route()).isNotNull();
             softly.assertThat(tripResponse.status()).isNotNull();
         });
     }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -154,7 +154,7 @@ class TripControllerTest extends ControllerTest {
             softly.assertThat(response.statusCode()).isEqualTo(OK.value());
             softly.assertThat(tripResponse.tripId()).isNotNull();
             softly.assertThat(tripResponse.name()).isNotNull();
-            softly.assertThat(tripResponse.routes()).isNotNull();
+            softly.assertThat(tripResponse.route()).isNotNull();
             softly.assertThat(tripResponse.status()).isNotNull();
         });
     }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #176 

### 📁 작업 설명

- 여행 단일 조회 필드명 routes에서 route로 변경