### PR TITLE
[fix] 감상 목록 정렬 (#194)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -23,7 +23,9 @@ import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.exception.member.MemberException;
 import dev.tripdraw.exception.post.PostException;
 import dev.tripdraw.exception.trip.TripException;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -112,7 +114,9 @@ public class PostService {
         Member member = findMemberByNickname(loginUser.nickname());
         findValidatedTripById(tripId, member);
 
-        List<Post> posts = postRepository.findAllByTripId(tripId);
+        List<Post> posts = postRepository.findAllByTripId(tripId).stream()
+                .sorted(Comparator.comparing(Post::pointRecordedAt).reversed())
+                .collect(Collectors.toList());
         return PostsResponse.from(posts);
     }
 

--- a/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/PostServiceTest.java
@@ -248,7 +248,7 @@ class PostServiceTest {
     void 특정_여행의_모든_감상을_조회한다() {
         // given
         createPost();
-        createPost();
+        createPost2();
 
         // when
         PostsResponse postsResponse = postService.readAllByTripId(loginUser, trip.id());
@@ -257,7 +257,7 @@ class PostServiceTest {
         List<PostResponse> posts = postsResponse.posts();
         assertSoftly(softly -> {
             softly.assertThat(posts.get(0).postId()).isNotNull();
-            softly.assertThat(posts.get(0).title()).isEqualTo("우도의 바닷가");
+            softly.assertThat(posts.get(0).title()).isEqualTo("우도의 땅콩 아이스크림");
             softly.assertThat(posts.get(0).pointResponse().pointId()).isNotNull();
             softly.assertThat(posts.get(1).postId()).isNotNull();
             softly.assertThat(posts.get(1).title()).isEqualTo("우도의 바닷가");
@@ -293,7 +293,7 @@ class PostServiceTest {
     }
 
     private PostCreateResponse createPost() {
-        PostAndPointCreateRequest postPointCreateRequest = new PostAndPointCreateRequest(
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
                 trip.id(),
                 "우도의 바닷가",
                 "제주특별자치도 제주시 애월읍 소길리",
@@ -303,6 +303,20 @@ class PostServiceTest {
                 LocalDateTime.of(2023, 7, 18, 20, 24)
         );
 
-        return postService.addAtCurrentPoint(loginUser, postPointCreateRequest, null);
+        return postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, null);
+    }
+
+    private PostCreateResponse createPost2() {
+        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
+                trip.id(),
+                "우도의 땅콩 아이스크림",
+                "제주특별자치도 제주시 애월읍 소길리",
+                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                1.2,
+                2.2,
+                LocalDateTime.of(2023, 7, 20, 12, 13)
+        );
+
+        return postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, null);
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #194 

### 📁 작업 설명

- 감상 목록 정렬되지 않는 문제 해결
    - 위치의 recordedAt 필드의 역순으로 정렬
- rebase과정에서 삭제되었던 테스트 복구