### PR TITLE
[fix] 삭제된 위치 정보가 조회되지 않도록 수정 (#221)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -150,7 +150,9 @@ public class Trip extends BaseEntity {
     }
 
     public List<Point> points() {
-        return route.points();
+        return route.points().stream()
+                .filter(point -> !point.isDeleted())
+                .toList();
     }
 
     public TripStatus status() {

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -262,4 +262,19 @@ class TripTest {
         // then
         assertThat(pointedLongitudes).containsExactly(2.2, 6.6);
     }
+
+    @Test
+    void 여행의_위치정보_중_삭제되지_않은_위치정보를_반환한다() {
+        // given
+        Member member = new Member("통후추");
+        Trip trip = Trip.from(member);
+        Point point1 = new Point(1.1, 2.2, LocalDateTime.now());
+        Point point2 = new Point(3.3, 4.4, LocalDateTime.now());
+        trip.add(point1);
+        trip.add(point2);
+        point2.delete();
+
+        // expect
+        assertThat(trip.points()).containsExactly(point1);
+    }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #221 

### 📁 작업 설명

- 삭제된 위치 정보가 조회되지 않도록 수정했습니다.