### PR TITLE
[fix] 수정하지 않은 감상의 이미지 그대로 유지 (#249)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/application/PostService.java
@@ -138,7 +138,6 @@ public class PostService {
 
     private void updateFileOfPost(MultipartFile file, Post post) {
         if (file == null) {
-            post.removePostImageUrl();
             return;
         }
         String imageUrl = fileUploader.upload(file, POST_IMAGE);


### PR DESCRIPTION
### 📌 관련 이슈

- closed #249 

### 📁 작업 설명
- As-is : 감상 수정 시, multipart/form-data의 file 필드를 넣지 않으면, 기존에 저장된 이미지가 null로 변환됨
- To-be : 감상 수정 시, multipart/form-data의 file 필드를 넣지 않으면, 기존에 저장된 이미지가 그대로 유지됨

### 💻 미완료 태스크(선택)

- [ ] MultipartFile 사용하는 PostController, PostService 테스트 추가
