### PR TITLE
[refactor] 모든 여행 조회 응답 수정 (#251)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -21,6 +21,8 @@ import java.util.List;
 @Entity
 public class Trip extends BaseEntity {
 
+    private static final String EMPTY_IMAGE_URL = "";
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "trip_id")
@@ -47,14 +49,16 @@ public class Trip extends BaseEntity {
     }
 
     public Trip(TripName name, Member member) {
-        this(null, name, member, ONGOING);
+        this(null, name, member, ONGOING, EMPTY_IMAGE_URL, EMPTY_IMAGE_URL);
     }
 
-    public Trip(Long id, TripName name, Member member, TripStatus status) {
+    public Trip(Long id, TripName name, Member member, TripStatus status, String imageUrl, String routeImageUrl) {
         this.id = id;
         this.name = name;
         this.member = member;
         this.status = status;
+        this.imageUrl = imageUrl;
+        this.routeImageUrl = routeImageUrl;
     }
 
     public static Trip from(Member member) {

--- a/backend/src/main/java/dev/tripdraw/dto/trip/TripSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/trip/TripSearchResponse.java
@@ -2,16 +2,30 @@ package dev.tripdraw.dto.trip;
 
 import dev.tripdraw.domain.trip.Trip;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 
 public record TripSearchResponse(
         @Schema(description = "여행 Id", example = "1")
         Long tripId,
 
         @Schema(description = "여행명", example = "통후추의 여행")
-        String name
+        String name,
+
+        @Schema(description = "이미지 주소", example = "https://tripdraw.site/post-images/cd678ca2-30d5-11ee-be56-0242ac120002.jpg")
+        String imageUrl,
+
+        @Schema(description = "경로 이미지 주소", example = "https://tripdraw.site/route-images/cd678ca2-30d5-11ee-be56-0242ac120002.png")
+        String routeImageUrl
 ) {
 
+    private static final String EMPTY_IMAGE_URL = "";
+
     public static TripSearchResponse from(Trip trip) {
-        return new TripSearchResponse(trip.id(), trip.nameValue());
+        return new TripSearchResponse(
+                trip.id(),
+                trip.nameValue(),
+                Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL),
+                Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL)
+        );
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -175,7 +175,8 @@ class TripServiceTest {
 
         // then
         assertThat(tripsSearchResponse).usingRecursiveComparison().isEqualTo(
-                new TripsSearchResponse(List.of(new TripSearchResponse(trip.id(), trip.nameValue())))
+                new TripsSearchResponse(List.of(new TripSearchResponse(trip.id(), trip.nameValue(), trip.imageUrl(),
+                        trip.routeImageUrl())))
         );
     }
 

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -175,8 +175,14 @@ class TripServiceTest {
 
         // then
         assertThat(tripsSearchResponse).usingRecursiveComparison().isEqualTo(
-                new TripsSearchResponse(List.of(new TripSearchResponse(trip.id(), trip.nameValue(), trip.imageUrl(),
-                        trip.routeImageUrl())))
+                new TripsSearchResponse(List.of(
+                        new TripSearchResponse(
+                                trip.id(),
+                                trip.nameValue(),
+                                trip.imageUrl(),
+                                trip.routeImageUrl()
+                        )
+                ))
         );
     }
 

--- a/backend/src/test/java/dev/tripdraw/dto/trip/TripSearchResponseTest.java
+++ b/backend/src/test/java/dev/tripdraw/dto/trip/TripSearchResponseTest.java
@@ -1,0 +1,33 @@
+package dev.tripdraw.dto.trip;
+
+import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
+import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.trip.Trip;
+import dev.tripdraw.domain.trip.TripName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TripSearchResponseTest {
+
+    @Test
+    void 여행_이미지와_경로_이미지가_null이면_빈값으로_변환해_생성한다() {
+        // given
+        Member member = new Member("통후추", "kakaoId", KAKAO);
+        TripName tripName = TripName.from("통후추의 여행");
+        Trip trip = new Trip(1L, tripName, member, ONGOING, null, null);
+
+        // when
+        TripSearchResponse response = TripSearchResponse.from(trip);
+
+        // then
+        assertThat(response).usingRecursiveComparison().isEqualTo(
+                TripSearchResponse.from(new Trip(1L, tripName, member, ONGOING, "", ""))
+        );
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -313,7 +313,14 @@ class TripControllerTest extends ControllerTest {
         assertSoftly(softly -> {
             softly.assertThat(response.statusCode()).isEqualTo(OK.value());
             softly.assertThat(tripsSearchResponse).usingRecursiveComparison().isEqualTo(
-                    new TripsSearchResponse(List.of(new TripSearchResponse(trip.id(), trip.nameValue())))
+                    new TripsSearchResponse(
+                            List.of(new TripSearchResponse(
+                                    trip.id(),
+                                    trip.nameValue(),
+                                    trip.imageUrl(),
+                                    trip.routeImageUrl())
+                            )
+                    )
             );
         });
     }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #251 

### 📁 작업 설명

- 모든 여행 조회의 응답을 수정합니다.
- Trip 생성자에서 imageUrl, routeImageUrl을 빈값으로 초기화할 수 있도록 수정합니다.