### PR TITLE
[docs] Swagger를 고도화한다 (#253)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/config/swagger/MultipartJackson2HttpMessageConverter.java
+++ b/backend/src/main/java/dev/tripdraw/config/swagger/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package dev.tripdraw.config.swagger;
+
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -3,6 +3,7 @@ package dev.tripdraw.presentation.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import dev.tripdraw.application.PostService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
@@ -19,7 +20,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,14 +42,14 @@ public class PostController {
         this.postService = postService;
     }
 
-    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상을 생성합니다.")
+    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "현재 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "현재 위치에 대한 감상 생성 성공."
     )
     @PostMapping(
             path = "/posts/current-location",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            consumes = MULTIPART_FORM_DATA_VALUE,
             produces = APPLICATION_JSON_VALUE
     )
     public ResponseEntity<PostCreateResponse> createOfCurrentLocation(
@@ -68,14 +68,14 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상을 생성합니다.")
+    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "사용자가 선택한 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "사용자가 선택한 위치에 대한 감상 생성 성공."
     )
     @PostMapping(
             path = "/posts",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            consumes = MULTIPART_FORM_DATA_VALUE,
             produces = APPLICATION_JSON_VALUE
     )
     public ResponseEntity<PostCreateResponse> create(
@@ -130,7 +130,7 @@ public class PostController {
     )
     @PatchMapping(
             path = "/posts/{postId}",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+            consumes = MULTIPART_FORM_DATA_VALUE
     )
     public ResponseEntity<Void> update(
             @Auth

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -42,7 +42,7 @@ public class PostController {
         this.postService = postService;
     }
 
-    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상 생성")
+    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "현재 위치에 대한 감상 생성 성공."
@@ -68,7 +68,7 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상 생성")
+    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "사용자가 선택한 위치에 대한 감상 생성 성공."
@@ -95,7 +95,7 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "특정 감상 상세 조회 API", description = "특정한 1개 감상의 상세 정보 조회")
+    @Operation(summary = "특정 감상 상세 조회 API", description = "특정한 1개의 감상을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "특정 감상 상세 조회 성공."
@@ -109,7 +109,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상 정보 조회")
+    @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "특정 여행의 모든 감상 조회 성공."
@@ -123,7 +123,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "감상 수정 API", description = "주소를 제외한 감상의 모든 정보를 수정")
+    @Operation(summary = "감상 수정 API", description = "주소를 제외한 감상의 모든 정보를 수정합니다.")
     @ApiResponse(
             responseCode = "204",
             description = "감상 수정 성공."
@@ -149,7 +149,7 @@ public class PostController {
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    @Operation(summary = "감상 삭제 API", description = "감상 삭제")
+    @Operation(summary = "감상 삭제 API", description = "특정한 1개의 감상을 삭제합니다.")
     @ApiResponse(
             responseCode = "204",
             description = "감상 삭제 성공."

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -2,6 +2,7 @@ package dev.tripdraw.presentation.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import dev.tripdraw.application.PostService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
@@ -14,15 +15,18 @@ import dev.tripdraw.dto.post.PostUpdateRequest;
 import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,11 +47,22 @@ public class PostController {
             responseCode = "201",
             description = "현재 위치에 대한 감상 생성 성공."
     )
-    @PostMapping("/posts/current-location")
+    @PostMapping(
+            path = "/posts/current-location",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<PostCreateResponse> createOfCurrentLocation(
             @Auth LoginUser loginUser,
-            @Valid @RequestPart(value = "dto") PostAndPointCreateRequest postAndPointCreateRequest,
-            @RequestPart(value = "file", required = false) MultipartFile file
+
+            @Parameter(description = "감상 정보를 담은 JSON 객체")
+            @Valid
+            @RequestPart(value = "dto")
+            PostAndPointCreateRequest postAndPointCreateRequest,
+
+            @Parameter(description = "감상에 등록할 이미지 파일")
+            @RequestPart(value = "file", required = false)
+            MultipartFile file
     ) {
         PostCreateResponse response = postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, file);
         return ResponseEntity.status(CREATED).body(response);
@@ -58,11 +73,23 @@ public class PostController {
             responseCode = "201",
             description = "사용자가 선택한 위치에 대한 감상 생성 성공."
     )
-    @PostMapping("/posts")
+    @PostMapping(
+            path = "/posts",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<PostCreateResponse> create(
-            @Auth LoginUser loginUser,
-            @Valid @RequestPart(value = "dto") PostRequest postRequest,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @Auth
+            LoginUser loginUser,
+
+            @Parameter(description = "감상 정보를 담은 JSON 객체")
+            @Valid
+            @RequestPart(value = "dto")
+            PostRequest postRequest,
+
+            @Parameter(description = "감상에 등록할 이미지 파일")
+            @RequestParam(value = "file", required = false)
+            MultipartFile file
     ) {
         PostCreateResponse response = postService.addAtExistingLocation(loginUser, postRequest, file);
         return ResponseEntity.status(CREATED).body(response);
@@ -101,11 +128,21 @@ public class PostController {
             responseCode = "204",
             description = "감상 수정 성공."
     )
-    @PatchMapping("/posts/{postId}")
+    @PatchMapping(
+            path = "/posts/{postId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
     public ResponseEntity<Void> update(
-            @Auth LoginUser loginUser,
+            @Auth
+            LoginUser loginUser,
+
             @PathVariable Long postId,
-            @Valid @RequestPart(value = "dto") PostUpdateRequest postUpdateRequest,
+
+            @Parameter(description = "수정할 감상 정보를 담은 JSON 객체")
+            @Valid @RequestPart(value = "dto")
+            PostUpdateRequest postUpdateRequest,
+
+            @Parameter(description = "감상에 등록할 이미지 파일")
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
         postService.update(loginUser, postId, postUpdateRequest, file);


### PR DESCRIPTION
### 📌 관련 이슈

- closed #253 

### 📁 작업 설명

- [x] Request에 multipart/form-data 적용
    - 현재 위치의 감상 생성 API
    - 사용자가 선택한 위치의 감상 생성 API
    - 감상 수정 API
- [x] application/octet-stream 타입 지원하도록 Converter 생성
    - Swagger에서 multipart를 입력하는 API 테스트 시 발생하는 문제를 해결하기 위한 것으로, Postman 또는 클라이언트의 일반 호출에서는 해당 타입이 사용되지 않습니다.
- [x] 용어 통일 등 자잘한 수정

