### PR TITLE
[feat] Firebase Crashlytics 연결 (#258)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
     id("kotlin-parcelize")
     // FireBase
     id("com.google.gms.google-services")
+    // FireBaseCrashlytics
+    id("com.google.firebase.crashlytics")
 }
 
 android {
@@ -129,7 +131,10 @@ dependencies {
 
     // FireBase
     implementation(platform(libs.fireBaseBom))
-    implementation(libs.fireBaseAnalyticsKtx)
+    // FireBaseAnalytics
+    releaseImplementation(libs.fireBaseAnalyticsKtx)
+    // FirebaseCrashlytics
+    releaseImplementation(libs.fireBaseCrashlyticsKtx)
 
     // EncryptedSharedPreference
     implementation(libs.encryptedSharedPreference)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.mannodermaus) apply false
     alias(libs.plugins.jlleitschuh) apply false
     alias(libs.plugins.fireBasePlugIn) apply false
+    alias(libs.plugins.firebaseCrashlyticsPlugIn) apply false
 }
 
 allprojects {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -77,6 +77,9 @@ coroutineTest = "1.7.2"
 # Stfalcon
 stfalcon = "v1.0.1"
 
+# firebaseCrashlytics
+firebaseCrashlyticsPlugIn = "2.9.8"
+
 [libraries]
 # AndroidX Libraries
 coreKtx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -137,7 +140,10 @@ gmsPlayServicesLocation = { module = "com.google.android.gms:play-services-locat
 
 # fireBase
 fireBaseBom = { module = "com.google.firebase:firebase-bom", version.ref = "fireBaseBom" }
+# googleAnalytics
 fireBaseAnalyticsKtx = { module = "com.google.firebase:firebase-analytics-ktx" }
+# firebaseCrashlytics
+fireBaseCrashlyticsKtx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 
 #EncryptedSharedPreference
 encryptedSharedPreference = { module = "androidx.security:security-crypto", version.ref = "encryptedSharedPreference" }
@@ -155,7 +161,6 @@ androidTest = ["androidTestJunit", "androidxTestEspresso", "mockkAndroid", "mock
 httpClient = ["okhttp", "retrofit", "moshi", "moshiConverter", "loggingInterceptor"]
 androidDefault = ["coreKtx", "appcompat", "constraintlayout", "material", "fragmentKtx"]
 naverMap = ["naverMap", "gmsPlayServicesLocation"]
-fireBase = ["fireBaseBom", "fireBaseAnalyticsKtx"]
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "gradleplugin" }
@@ -167,6 +172,8 @@ kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 jlleitschuh = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "jlleitschuh" }
 # fireBase
 fireBasePlugIn = { id = "com.google.gms.google-services", version.ref = "fireBasePlugIn" }
+# firebaseCrashlytics
+firebaseCrashlyticsPlugIn = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugIn" }
 
 # use junit5 for test
 mannodermaus = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus" }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #258 

### 📁 작업 설명

- 버그 리포팅을 위한 Firebase Crashlytics를 연결한다
- GA또한 로깅시스템을 위해 연결한다
- 슬랙을 연결하여 빠르게 버그리포팅을 한다.

