### PR TITLE
[feat] 여행 히스토리 / 여행 제목 수정 기능 (#262)

### DIFF
--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/bindingAdapter/TripTitleDialogBindingAdapter.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/bindingAdapter/TripTitleDialogBindingAdapter.kt
@@ -3,10 +3,28 @@ package com.teamtripdraw.android.ui.common.bindingAdapter
 import android.view.View
 import android.widget.EditText
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.res.ResourcesCompat
 import androidx.databinding.BindingAdapter
 import com.teamtripdraw.android.R
 import com.teamtripdraw.android.domain.model.trip.TripTitleValidState
+
+@BindingAdapter("app:setDialogButtonEnabled")
+fun AppCompatButton.setDialogButtonEnabled(state: TripTitleValidState) {
+    val btnEnabled: Boolean = when (state) {
+        TripTitleValidState.AVAILABLE -> true
+        TripTitleValidState.EXCEED_LIMIT, TripTitleValidState.CONTAIN_BLANK -> false
+    }
+    val btnBackground =
+        if (btnEnabled) {
+            R.drawable.shape_td_main_blue_fill_5_rect
+        } else {
+            R.drawable.shape_td_gray_fill_5_rect
+        }
+
+    this.isEnabled = btnEnabled
+    this.background = ResourcesCompat.getDrawable(resources, btnBackground, null)
+}
 
 @BindingAdapter("app:setDialogEditTextBackground")
 fun EditText.setDialogEditTextBackground(state: TripTitleValidState) {

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialog.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialog.kt
@@ -12,6 +12,7 @@ import com.teamtripdraw.android.support.framework.presentation.event.EventObserv
 import com.teamtripdraw.android.support.framework.presentation.getParcelableCompat
 import com.teamtripdraw.android.ui.common.tripDrawViewModelFactory
 import com.teamtripdraw.android.ui.history.detail.HistoryDetailActivity
+import com.teamtripdraw.android.ui.history.detail.HistoryDetailViewModel
 import com.teamtripdraw.android.ui.home.HomeViewModel
 import com.teamtripdraw.android.ui.model.UiPreviewTrip
 
@@ -21,6 +22,7 @@ class SetTripTitleDialog : DialogFragment() {
     private val binding get() = _binding!!
     private val viewModel: SetTripTitleDialogViewModel by viewModels { tripDrawViewModelFactory }
     private val homeViewModel: HomeViewModel by viewModels({ requireParentFragment() })
+    private val historyDetailViewModel: HistoryDetailViewModel by viewModels({ requireActivity() })
 
     private val tripId by lazy { requireArguments().getLong(TRIP_ID_KEY) }
     private val status by lazy {
@@ -84,10 +86,12 @@ class SetTripTitleDialog : DialogFragment() {
                 SetTitleSituation.FINISHED -> {
                     viewModel.getTripPreviewInfo()
                     homeViewModel.finishTripCompleteEvent()
-                    dismiss()
                 }
-                SetTitleSituation.EDIT -> dismiss()
+                SetTitleSituation.EDIT -> {
+                    historyDetailViewModel.updateTripTitle(viewModel.tripTitle.value ?: "")
+                }
             }
+            dismiss()
         }
     }
 

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialog.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialog.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.teamtripdraw.android.R
 import com.teamtripdraw.android.databinding.FragmentTripTitleDialogBinding
@@ -22,7 +23,7 @@ class SetTripTitleDialog : DialogFragment() {
     private val binding get() = _binding!!
     private val viewModel: SetTripTitleDialogViewModel by viewModels { tripDrawViewModelFactory }
     private val homeViewModel: HomeViewModel by viewModels({ requireParentFragment() })
-    private val historyDetailViewModel: HistoryDetailViewModel by viewModels({ requireActivity() })
+    private val historyDetailViewModel: HistoryDetailViewModel by activityViewModels()
 
     private val tripId by lazy { requireArguments().getLong(TRIP_ID_KEY) }
     private val status by lazy {

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialogViewModel.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialogViewModel.kt
@@ -13,11 +13,13 @@ import com.teamtripdraw.android.domain.model.trip.TripTitleValidState
 import com.teamtripdraw.android.domain.repository.TripRepository
 import com.teamtripdraw.android.support.framework.presentation.event.Event
 import com.teamtripdraw.android.ui.model.UiPreviewTrip
+import com.teamtripdraw.android.ui.model.mapper.toDomain
 import com.teamtripdraw.android.ui.model.mapper.toPresentation
+import com.teamtripdraw.android.ui.model.mapper.toPreviewPresentation
 import kotlinx.coroutines.launch
 
 class SetTripTitleDialogViewModel(
-    private val repository: TripRepository
+    private val repository: TripRepository,
 ) : ViewModel() {
 
     val MAX_INPUT_TITLE_LENGTH = TripTitleValidState.MAX_TITLE_LENGTH + 1
@@ -52,13 +54,22 @@ class SetTripTitleDialogViewModel(
                 tripId = tripId,
                 preSetTripTitle = PreSetTripTitle(
                     requireNotNull(tripTitle.value),
-                    TripStatus.FINISHED
-                )
+                    TripStatus.FINISHED,
+                ),
             ).onSuccess {
                 _titleSetupCompletedEvent.value = Event(true)
             }.onFailure {
                 // todo 오류 처리
             }
+        }
+    }
+
+    fun getTripPreviewInfo() {
+        viewModelScope.launch {
+            repository.getTrip(tripId)
+                .onSuccess {
+                    _previewTrip.value = it.toPreviewPresentation().toDomain()
+                }
         }
     }
 }

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/history/HistoryFragment.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/history/HistoryFragment.kt
@@ -27,9 +27,7 @@ class HistoryFragment : Fragment() {
     ): View {
         _binding = FragmentHistoryBinding.inflate(inflater)
         binding.lifecycleOwner = viewLifecycleOwner
-
         setAdapter()
-        getPreviewTrips()
         initObserve()
 
         return binding.root
@@ -39,8 +37,6 @@ class HistoryFragment : Fragment() {
         historyAdapter = HistoryAdapter(viewModel)
         binding.rvTripHistory.adapter = historyAdapter
     }
-
-    private fun getPreviewTrips() = viewModel.getPreviewTrips()
 
     private fun initObserve() {
         initPreviewTripsObserve()
@@ -64,6 +60,13 @@ class HistoryFragment : Fragment() {
         val intent = HistoryDetailActivity.getIntent(requireContext(), previewTrip)
         startActivity(intent)
     }
+
+    override fun onStart() {
+        super.onStart()
+        getPreviewTrips()
+    }
+
+    private fun getPreviewTrips() = viewModel.getPreviewTrips()
 
     override fun onDestroy() {
         super.onDestroy()

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailActivity.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailActivity.kt
@@ -88,6 +88,7 @@ class HistoryDetailActivity : AppCompatActivity() {
             binding.ivHistoryDetailImage.setImage(it.imageUrl)
             binding.ivHistoryDetailRoute.setImage(it.routeImageUrl)
             binding.tbHistoryDetail.title = it.name
+            binding.invalidateAll() // DataBinding 오류 : 이슈 #262 참고
         }
     }
 

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailActivity.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailActivity.kt
@@ -12,6 +12,8 @@ import com.teamtripdraw.android.support.framework.presentation.event.EventObserv
 import com.teamtripdraw.android.support.framework.presentation.getParcelableExtraCompat
 import com.teamtripdraw.android.ui.common.bindingAdapter.setImage
 import com.teamtripdraw.android.ui.common.dialog.DialogUtil
+import com.teamtripdraw.android.ui.common.dialog.SetTitleSituation
+import com.teamtripdraw.android.ui.common.dialog.SetTripTitleDialog
 import com.teamtripdraw.android.ui.common.tripDrawViewModelFactory
 import com.teamtripdraw.android.ui.history.tripDetail.TripDetailActivity
 import com.teamtripdraw.android.ui.model.UiPreviewTrip
@@ -59,6 +61,9 @@ class HistoryDetailActivity : AppCompatActivity() {
         binding.ivHistoryDetailImage.setOnClickListener {
             viewModel.openTripDetail()
         }
+        binding.btnHistoryDetailEdit.setOnClickListener {
+            viewModel.openEditTitle()
+        }
     }
 
     private fun initObserve() {
@@ -67,6 +72,7 @@ class HistoryDetailActivity : AppCompatActivity() {
         initTripDetailEventObserve()
         initPostDetailEventObserve()
         initDeleteDialogEventObserve()
+        initEditTripTitleObserve()
         initDeleteCompleteObserve()
     }
 
@@ -121,6 +127,19 @@ class HistoryDetailActivity : AppCompatActivity() {
             DialogUtil(DialogUtil.DELETE_CHECK) { viewModel.deleteTrip() }
                 .show(supportFragmentManager, this.javaClass.name)
         }
+    }
+
+    private fun initEditTripTitleObserve() {
+        viewModel.openEditTripTitleEvent.observe(this) {
+            showEditTripTitleDialog()
+        }
+    }
+
+    private fun showEditTripTitleDialog() {
+        val setTripTitleDialog = SetTripTitleDialog()
+        setTripTitleDialog.arguments =
+            SetTripTitleDialog.getBundle(viewModel.tripId, SetTitleSituation.EDIT)
+        setTripTitleDialog.show(supportFragmentManager, this.javaClass.name)
     }
 
     private fun initDeleteCompleteObserve() =

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailViewModel.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailViewModel.kt
@@ -45,6 +45,12 @@ class HistoryDetailViewModel(
         _previewTrip.value = previewTrip
     }
 
+    fun updateTripTitle(title: String) {
+        _previewTrip.value = _previewTrip.value!!.run {
+            UiPreviewTrip(id, title, imageUrl, routeImageUrl)
+        }
+    }
+
     fun getPosts() {
         viewModelScope.launch {
             postRepository.getAllPosts(tripId)

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailViewModel.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/history/detail/HistoryDetailViewModel.kt
@@ -21,7 +21,7 @@ class HistoryDetailViewModel(
     private val _previewTrip: MutableLiveData<UiPreviewTrip> = MutableLiveData()
     val previewTrip: LiveData<UiPreviewTrip> = _previewTrip
 
-    private val tripId get() = previewTrip.value?.id ?: NULL_SUBSTITUTE_TRIP_ID
+    val tripId get() = previewTrip.value?.id ?: NULL_SUBSTITUTE_TRIP_ID
 
     private val _posts: MutableLiveData<List<UiPostItem>> = MutableLiveData()
     val post: LiveData<List<UiPostItem>> = _posts
@@ -31,6 +31,9 @@ class HistoryDetailViewModel(
 
     private val _openPostDetailEvent = MutableLiveData<Event<Long>>()
     val openPostDetailEvent: LiveData<Event<Long>> = _openPostDetailEvent
+
+    private val _openEditTripTitleEvent = MutableLiveData<Boolean>()
+    val openEditTripTitleEvent: LiveData<Boolean> = _openEditTripTitleEvent
 
     private val _openDeleteDialogEvent = MutableLiveData<Event<Boolean>>()
     val openDeleteDialogEvent: LiveData<Event<Boolean>> = _openDeleteDialogEvent
@@ -65,6 +68,10 @@ class HistoryDetailViewModel(
 
     fun openPostDetail(postId: Long) {
         _openPostDetailEvent.value = Event(postId)
+    }
+
+    fun openEditTitle() {
+        _openEditTripTitleEvent.value = true
     }
 
     fun openDeleteDialog() {

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/home/markerSelectedBottomSheet/MarkerSelectedBottomSheet.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/home/markerSelectedBottomSheet/MarkerSelectedBottomSheet.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.teamtripdraw.android.R
@@ -43,7 +44,7 @@ class MarkerSelectedBottomSheet : BottomSheetDialogFragment() {
                 homeViewModel
             }
             BottomSheetClickSituation.HISTORY -> {
-                val tripDetailViewModel: TripDetailViewModel by viewModels({ requireActivity() })
+                val tripDetailViewModel: TripDetailViewModel by activityViewModels()
                 tripDetailViewModel
             }
         }

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/model/mapper/TripUiMapper.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/model/mapper/TripUiMapper.kt
@@ -2,6 +2,7 @@ package com.teamtripdraw.android.ui.model.mapper
 
 import com.teamtripdraw.android.domain.model.point.Route
 import com.teamtripdraw.android.domain.model.trip.PreviewTrip
+import com.teamtripdraw.android.domain.model.trip.Trip
 import com.teamtripdraw.android.ui.model.UiPreviewTrip
 import com.teamtripdraw.android.ui.model.UiRoute
 
@@ -17,4 +18,20 @@ fun PreviewTrip.toPresentation(): UiPreviewTrip =
         name = this.name,
         imageUrl = this.imageUrl,
         routeImageUrl = this.routeImageUrl,
+    )
+
+fun Trip.toPreviewPresentation(): UiPreviewTrip =
+    UiPreviewTrip(
+        id = tripId,
+        name = name,
+        imageUrl = imageUrl ?: "",
+        routeImageUrl = routeImageUrl ?: "",
+    )
+
+fun UiPreviewTrip.toDomain(): PreviewTrip =
+    PreviewTrip(
+        id = id,
+        name = name,
+        imageUrl = imageUrl,
+        routeImageUrl = routeImageUrl,
     )

--- a/android/app/src/main/res/drawable/shape_td_gray_fill_5_rect.xml
+++ b/android/app/src/main/res/drawable/shape_td_gray_fill_5_rect.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/td_gray" />
+    <corners android:radius="5dp" />
+</shape>

--- a/android/app/src/main/res/layout/fragment_trip_title_dialog.xml
+++ b/android/app/src/main/res/layout/fragment_trip_title_dialog.xml
@@ -65,7 +65,8 @@
             app:layout_constraintBottom_toBottomOf="@+id/et_dialog_input"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/et_dialog_input"
-            app:layout_constraintTop_toTopOf="@+id/et_dialog_input" />
+            app:layout_constraintTop_toTopOf="@+id/et_dialog_input"
+            app:setDialogButtonEnabled="@{insertTripTitleDialogViewModel.titleState}" />
 
         <TextView
             android:id="@+id/tv_title_valid_state_warning_message"


### PR DESCRIPTION
### 📌 관련 이슈

- closed #262 

### 📁 작업 설명

- 여행 히스토리 상세 화면에서 여행 제목 수정 기능
- 제목 수정 후 화면 이동 혹은 화면 업데이트 작업
- 제목 수정 다이얼로그 버튼 활성/비활성 기능

