### PR TITLE
[feat] 여행 삭제 기능 추가 및 회원 탈퇴 기능 수정 (#255)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 processResources.dependsOn('copySecret')

--- a/backend/src/main/java/dev/tripdraw/application/MemberService.java
+++ b/backend/src/main/java/dev/tripdraw/application/MemberService.java
@@ -5,6 +5,8 @@ import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND
 import dev.tripdraw.application.oauth.AuthTokenManager;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.domain.post.PostRepository;
+import dev.tripdraw.domain.trip.TripRepository;
 import dev.tripdraw.dto.member.MemberSearchResponse;
 import dev.tripdraw.exception.member.MemberException;
 import org.springframework.stereotype.Service;
@@ -15,10 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final TripRepository tripRepository;
+    private final PostRepository postRepository;
     private final AuthTokenManager authTokenManager;
 
-    public MemberService(MemberRepository memberRepository, AuthTokenManager authTokenManager) {
+    public MemberService(MemberRepository memberRepository, TripRepository tripRepository,
+                         PostRepository postRepository, AuthTokenManager authTokenManager) {
         this.memberRepository = memberRepository;
+        this.tripRepository = tripRepository;
+        this.postRepository = postRepository;
         this.authTokenManager = authTokenManager;
     }
 
@@ -39,6 +46,9 @@ public class MemberService {
         Long memberId = authTokenManager.extractMemberId(code);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        postRepository.deleteByMemberId(memberId);
+        tripRepository.deleteByMemberId(memberId);
         memberRepository.delete(member);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/MemberService.java
+++ b/backend/src/main/java/dev/tripdraw/application/MemberService.java
@@ -39,6 +39,6 @@ public class MemberService {
         Long memberId = authTokenManager.extractMemberId(code);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
-        member.delete();
+        memberRepository.delete(member);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/MemberService.java
+++ b/backend/src/main/java/dev/tripdraw/application/MemberService.java
@@ -21,8 +21,12 @@ public class MemberService {
     private final PostRepository postRepository;
     private final AuthTokenManager authTokenManager;
 
-    public MemberService(MemberRepository memberRepository, TripRepository tripRepository,
-                         PostRepository postRepository, AuthTokenManager authTokenManager) {
+    public MemberService(
+            MemberRepository memberRepository,
+            TripRepository tripRepository,
+            PostRepository postRepository,
+            AuthTokenManager authTokenManager
+    ) {
         this.memberRepository = memberRepository;
         this.tripRepository = tripRepository;
         this.postRepository = postRepository;

--- a/backend/src/main/java/dev/tripdraw/application/MemberService.java
+++ b/backend/src/main/java/dev/tripdraw/application/MemberService.java
@@ -44,11 +44,8 @@ public class MemberService {
 
     public void deleteByCode(String code) {
         Long memberId = authTokenManager.extractMemberId(code);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
-
         postRepository.deleteByMemberId(memberId);
         tripRepository.deleteByMemberId(memberId);
-        memberRepository.delete(member);
+        memberRepository.deleteById(memberId);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -125,6 +125,10 @@ public class TripService {
     }
 
     public void delete(LoginUser loginUser, Long tripId) {
-        tripRepository.deleteById(tripId);
+        Member member = getById(loginUser.memberId());
+        Trip trip = getByTripId(tripId);
+        trip.validateAuthorization(member);
+
+        tripRepository.delete(trip);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -123,4 +123,8 @@ public class TripService {
         Point point = trip.findPointById(pointId);
         return PointResponse.from(point);
     }
+
+    public void delete(LoginUser loginUser, Long tripId) {
+        tripRepository.deleteById(tripId);
+    }
 }

--- a/backend/src/main/java/dev/tripdraw/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/config/AuthConfig.java
@@ -32,6 +32,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**")
-                .excludePathPatterns("/oauth/**");
+                .excludePathPatterns("/oauth/**")
+                .excludePathPatterns("/actuator/**");
     }
 }

--- a/backend/src/main/java/dev/tripdraw/config/swagger/MultipartJackson2HttpMessageConverter.java
+++ b/backend/src/main/java/dev/tripdraw/config/swagger/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package dev.tripdraw.config.swagger;
+
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/config/swagger/SwaggerConfig.java
+++ b/backend/src/main/java/dev/tripdraw/config/swagger/SwaggerConfig.java
@@ -36,7 +36,9 @@ public class SwaggerConfig {
         return new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme(BEARER_TYPE)
-                .description("Base64로 인코딩된 닉네임을 입력해주세요. 통후추 예시) 7Ya17ZuE7LaU");
+                .description(
+                        "로그인하고 받은 JWT를 입력해주세요. 예시) eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMzMiLCJleHAiOjE2OTE4OTA0NjZ9.NlzZEEDWdjovafRPCD1ZvddeRUccZfyZpcUWzGPAI4oK-PKyPM64TIMJ3HyOy29vJtg_MET1c4omWUkGOb4qyQ"
+                );
     }
 
     private Info info() {

--- a/backend/src/main/java/dev/tripdraw/domain/member/Member.java
+++ b/backend/src/main/java/dev/tripdraw/domain/member/Member.java
@@ -1,24 +1,16 @@
 package dev.tripdraw.domain.member;
 
-import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static jakarta.persistence.GenerationType.IDENTITY;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 
 import dev.tripdraw.domain.common.BaseEntity;
 import dev.tripdraw.domain.oauth.OauthType;
-import dev.tripdraw.exception.member.MemberException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
-@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE member_id = ?")
-@Where(clause = "is_deleted = FALSE")
 @Entity
 public class Member extends BaseEntity {
 
@@ -36,9 +28,6 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private OauthType oauthType;
 
-    @Column(nullable = false)
-    private Boolean isDeleted = FALSE;
-
     protected Member() {
     }
 
@@ -55,17 +44,6 @@ public class Member extends BaseEntity {
 
     public static Member of(String oauthId, OauthType oauthType) {
         return new Member(null, null, oauthId, oauthType);
-    }
-
-    public void delete() {
-        validateNotDeleted();
-        this.isDeleted = TRUE;
-    }
-
-    private void validateNotDeleted() {
-        if (isDeleted == TRUE) {
-            throw new MemberException(MEMBER_NOT_FOUND);
-        }
     }
 
     public void changeNickname(String nickname) {
@@ -86,9 +64,5 @@ public class Member extends BaseEntity {
 
     public OauthType oauthType() {
         return oauthType;
-    }
-
-    public Boolean isDeleted() {
-        return isDeleted;
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/post/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/domain/post/PostRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByTripId(Long tripId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
@@ -11,9 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
-import org.hibernate.annotations.Where;
 
-@Where(clause = "is_deleted = false")
 @Entity
 public class Point extends BaseEntity {
 

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Point.java
@@ -11,7 +11,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import org.hibernate.annotations.Where;
 
+@Where(clause = "is_deleted = false")
 @Entity
 public class Point extends BaseEntity {
 

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
@@ -2,7 +2,8 @@ package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
-import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 
 import dev.tripdraw.exception.trip.TripException;
@@ -16,7 +17,7 @@ import java.util.Objects;
 @Embeddable
 public class Route {
 
-    @OneToMany(fetch = LAZY, cascade = ALL)
+    @OneToMany(fetch = LAZY, cascade = {PERSIST, REMOVE})
     @JoinColumn(name = "trip_id", updatable = false, nullable = false)
     private List<Point> points = new ArrayList<>();
 

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
@@ -2,7 +2,7 @@ package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
-import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 
 import dev.tripdraw.exception.trip.TripException;
@@ -16,7 +16,7 @@ import java.util.Objects;
 @Embeddable
 public class Route {
 
-    @OneToMany(fetch = LAZY, cascade = PERSIST)
+    @OneToMany(fetch = LAZY, cascade = ALL)
     @JoinColumn(name = "trip_id", updatable = false, nullable = false)
     private List<Point> points = new ArrayList<>();
 

--- a/backend/src/main/java/dev/tripdraw/domain/trip/TripRepository.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/TripRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
-    
+
     List<Trip> findAllByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/dev/tripdraw/dto/member/MemberSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/member/MemberSearchResponse.java
@@ -2,6 +2,7 @@ package dev.tripdraw.dto.member;
 
 import dev.tripdraw.domain.member.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 
 public record MemberSearchResponse(
         @Schema(description = "사용자 Id", example = "1")
@@ -11,7 +12,9 @@ public record MemberSearchResponse(
         String nickname
 ) {
 
+    private static final String EMPTY_NICKNAME = "";
+
     public static MemberSearchResponse from(Member member) {
-        return new MemberSearchResponse(member.id(), member.nickname());
+        return new MemberSearchResponse(member.id(), Objects.requireNonNullElse(member.nickname(), EMPTY_NICKNAME));
     }
 }

--- a/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
@@ -16,6 +16,7 @@ public enum TripExceptionType implements ExceptionType {
     POINT_NOT_FOUND(NOT_FOUND, "존재하지 않는 위치입니다."),
     TRIP_INVALID_STATUS(BAD_REQUEST, "잘못된 여행 상태입니다."),
     POINT_ALREADY_HAS_POST(CONFLICT, "이미 감상이 등록된 위치입니다."),
+    TRIP_ALREADY_DELETED(CONFLICT, "이미 삭제된 여행입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -3,6 +3,7 @@ package dev.tripdraw.presentation.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import dev.tripdraw.application.PostService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
@@ -19,7 +20,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,14 +42,14 @@ public class PostController {
         this.postService = postService;
     }
 
-    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상을 생성합니다.")
+    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "현재 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "현재 위치에 대한 감상 생성 성공."
     )
     @PostMapping(
             path = "/posts/current-location",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            consumes = MULTIPART_FORM_DATA_VALUE,
             produces = APPLICATION_JSON_VALUE
     )
     public ResponseEntity<PostCreateResponse> createOfCurrentLocation(
@@ -68,14 +68,14 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상을 생성합니다.")
+    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "사용자가 선택한 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "사용자가 선택한 위치에 대한 감상 생성 성공."
     )
     @PostMapping(
             path = "/posts",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            consumes = MULTIPART_FORM_DATA_VALUE,
             produces = APPLICATION_JSON_VALUE
     )
     public ResponseEntity<PostCreateResponse> create(
@@ -130,7 +130,7 @@ public class PostController {
     )
     @PatchMapping(
             path = "/posts/{postId}",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+            consumes = MULTIPART_FORM_DATA_VALUE
     )
     public ResponseEntity<Void> update(
             @Auth

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -42,7 +42,7 @@ public class PostController {
         this.postService = postService;
     }
 
-    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상 생성")
+    @Operation(summary = "현재 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 현재 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "현재 위치에 대한 감상 생성 성공."
@@ -68,7 +68,7 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상 생성")
+    @Operation(summary = "사용자가 선택한 위치에 대한 감상 생성 API", description = "진행 중인 여행에서, 사용자가 선택한 위치에 대한 감상을 생성합니다.")
     @ApiResponse(
             responseCode = "201",
             description = "사용자가 선택한 위치에 대한 감상 생성 성공."
@@ -95,7 +95,7 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "특정 감상 상세 조회 API", description = "특정한 1개 감상의 상세 정보 조회")
+    @Operation(summary = "특정 감상 상세 조회 API", description = "특정한 1개의 감상을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "특정 감상 상세 조회 성공."
@@ -109,7 +109,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상 정보 조회")
+    @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상을 조회합니다.")
     @ApiResponse(
             responseCode = "200",
             description = "특정 여행의 모든 감상 조회 성공."
@@ -123,7 +123,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "감상 수정 API", description = "주소를 제외한 감상의 모든 정보를 수정")
+    @Operation(summary = "감상 수정 API", description = "주소를 제외한 감상의 모든 정보를 수정합니다.")
     @ApiResponse(
             responseCode = "204",
             description = "감상 수정 성공."
@@ -149,7 +149,7 @@ public class PostController {
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    @Operation(summary = "감상 삭제 API", description = "감상 삭제")
+    @Operation(summary = "감상 삭제 API", description = "특정한 1개의 감상을 삭제합니다.")
     @ApiResponse(
             responseCode = "204",
             description = "감상 삭제 성공."

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/PostController.java
@@ -2,6 +2,7 @@ package dev.tripdraw.presentation.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import dev.tripdraw.application.PostService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
@@ -14,15 +15,18 @@ import dev.tripdraw.dto.post.PostUpdateRequest;
 import dev.tripdraw.dto.post.PostsResponse;
 import dev.tripdraw.presentation.member.Auth;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,11 +47,22 @@ public class PostController {
             responseCode = "201",
             description = "현재 위치에 대한 감상 생성 성공."
     )
-    @PostMapping("/posts/current-location")
+    @PostMapping(
+            path = "/posts/current-location",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<PostCreateResponse> createOfCurrentLocation(
             @Auth LoginUser loginUser,
-            @Valid @RequestPart(value = "dto") PostAndPointCreateRequest postAndPointCreateRequest,
-            @RequestPart(value = "file", required = false) MultipartFile file
+
+            @Parameter(description = "감상 정보를 담은 JSON 객체")
+            @Valid
+            @RequestPart(value = "dto")
+            PostAndPointCreateRequest postAndPointCreateRequest,
+
+            @Parameter(description = "감상에 등록할 이미지 파일")
+            @RequestPart(value = "file", required = false)
+            MultipartFile file
     ) {
         PostCreateResponse response = postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, file);
         return ResponseEntity.status(CREATED).body(response);
@@ -58,11 +73,23 @@ public class PostController {
             responseCode = "201",
             description = "사용자가 선택한 위치에 대한 감상 생성 성공."
     )
-    @PostMapping("/posts")
+    @PostMapping(
+            path = "/posts",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<PostCreateResponse> create(
-            @Auth LoginUser loginUser,
-            @Valid @RequestPart(value = "dto") PostRequest postRequest,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @Auth
+            LoginUser loginUser,
+
+            @Parameter(description = "감상 정보를 담은 JSON 객체")
+            @Valid
+            @RequestPart(value = "dto")
+            PostRequest postRequest,
+
+            @Parameter(description = "감상에 등록할 이미지 파일")
+            @RequestParam(value = "file", required = false)
+            MultipartFile file
     ) {
         PostCreateResponse response = postService.addAtExistingLocation(loginUser, postRequest, file);
         return ResponseEntity.status(CREATED).body(response);
@@ -101,11 +128,21 @@ public class PostController {
             responseCode = "204",
             description = "감상 수정 성공."
     )
-    @PatchMapping("/posts/{postId}")
+    @PatchMapping(
+            path = "/posts/{postId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
     public ResponseEntity<Void> update(
-            @Auth LoginUser loginUser,
+            @Auth
+            LoginUser loginUser,
+
             @PathVariable Long postId,
-            @Valid @RequestPart(value = "dto") PostUpdateRequest postUpdateRequest,
+
+            @Parameter(description = "수정할 감상 정보를 담은 JSON 객체")
+            @Valid @RequestPart(value = "dto")
+            PostUpdateRequest postUpdateRequest,
+
+            @Parameter(description = "감상에 등록할 이미지 파일")
             @RequestPart(value = "file", required = false) MultipartFile file
     ) {
         postService.update(loginUser, postId, postUpdateRequest, file);

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/TripController.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.presentation.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import dev.tripdraw.application.TripService;
 import dev.tripdraw.config.swagger.SwaggerAuthorizationRequired;
@@ -127,5 +128,19 @@ public class TripController {
     ) {
         tripService.updateTripById(loginUser, tripId, tripUpdateRequest);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "여행 삭제 API", description = "여행 삭제")
+    @ApiResponse(
+            responseCode = "204",
+            description = "여행 삭제 성공."
+    )
+    @DeleteMapping("/trips/{tripId}")
+    public ResponseEntity<Void> delete(
+            @Auth LoginUser loginUser,
+            @PathVariable Long tripId
+    ) {
+        tripService.delete(loginUser, tripId);
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -54,6 +54,15 @@ jwt:
   secret-key: ItIsALocalKeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee2222222222222222222222222222222222eeeeeeeeeeyXD
   expiration-time: 172800000  # 48시간 millisecond
 
+management:
+  endpoint:
+    health:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+
 oauth:
   kakao:
     info-url: https://kapi.kakao.com/v2/user/me

--- a/backend/src/main/resources/db/migration/h2/V6__modifyMemberAndAddTripDeletion.sql
+++ b/backend/src/main/resources/db/migration/h2/V6__modifyMemberAndAddTripDeletion.sql
@@ -1,0 +1,1 @@
+alter table member drop column is_deleted;

--- a/backend/src/main/resources/db/migration/mysql/V6__modifyMemberAndAddTripDeletion.sql
+++ b/backend/src/main/resources/db/migration/mysql/V6__modifyMemberAndAddTripDeletion.sql
@@ -1,0 +1,1 @@
+alter table member drop column is_deleted;

--- a/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
@@ -77,7 +77,7 @@ class MemberServiceTest {
         memberService.deleteByCode(code);
 
         // then
-        assertThat(member.isDeleted()).isTrue();
+        assertThat(memberRepository.findById(member.id())).isEmpty();
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/MemberServiceTest.java
@@ -112,28 +112,4 @@ class MemberServiceTest {
             softly.assertThat(postRepository.findById(post.id())).isEmpty();
         });
     }
-
-    @Test
-    void code를_입력_받아_사용자를_삭제할_때_이미_삭제된_사용자라면_예외를_발생시킨다() {
-        // given
-        Member member = memberRepository.save(new Member("순후추", "kakaoId", KAKAO));
-        String code = authTokenManager.generate(member.id());
-
-        memberRepository.deleteById(member.id());
-
-        // expect
-        assertThatThrownBy(() -> memberService.deleteByCode(code))
-                .isInstanceOf(MemberException.class)
-                .hasMessage(MEMBER_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    void code를_입력_받아_사용자를_삭제할_때_존재하지_않는_사용자라면_예외를_발생시킨다() {
-        String nonExistentCode = authTokenManager.generate(MIN_VALUE);
-
-        // expect
-        assertThatThrownBy(() -> memberService.deleteByCode(nonExistentCode))
-                .isInstanceOf(MemberException.class)
-                .hasMessage(MEMBER_NOT_FOUND.getMessage());
-    }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
@@ -2,7 +2,6 @@ package dev.tripdraw.domain.member;
 
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -39,41 +38,5 @@ class MemberRepositoryTest {
 
         // expect
         assertThat(foundMember).isEmpty();
-    }
-
-    @Test
-    void ID를_입력_받아_사용자를_삭제한다() {
-        // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-
-        // when
-        memberRepository.deleteById(member.id());
-
-        // then
-        assertThat(memberRepository.findById(member.id())).isEmpty();
-    }
-
-    @Test
-    void ID를_입력_받아_사용자를_삭제할_때_존재하지_않는_사용자_ID여도_예외가_발생하지_않는다() {
-        // expect
-        assertThatNoException().isThrownBy(() -> memberRepository.deleteById(Long.MIN_VALUE));
-    }
-
-    @Test
-    void 사용자를_입력_받아_삭제한다() {
-        // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-
-        // when
-        memberRepository.delete(member);
-
-        // then
-        assertThat(memberRepository.findById(member.id())).isEmpty();
-    }
-
-    @Test
-    void 사용자를_입력_받아_삭제할_때_존재하지_않는_사용자여도_예외가_발생하지_않는다() {
-        // expect
-        assertThatNoException().isThrownBy(() -> memberRepository.delete(new Member("", "", KAKAO)));
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package dev.tripdraw.domain.member;
 
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -38,5 +39,41 @@ class MemberRepositoryTest {
 
         // expect
         assertThat(foundMember).isEmpty();
+    }
+
+    @Test
+    void ID를_입력_받아_사용자를_삭제한다() {
+        // given
+        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+
+        // when
+        memberRepository.deleteById(member.id());
+
+        // then
+        assertThat(memberRepository.findById(member.id())).isEmpty();
+    }
+
+    @Test
+    void ID를_입력_받아_사용자를_삭제할_때_존재하지_않는_사용자_ID여도_예외가_발생하지_않는다() {
+        // expect
+        assertThatNoException().isThrownBy(() -> memberRepository.deleteById(Long.MIN_VALUE));
+    }
+
+    @Test
+    void 사용자를_입력_받아_삭제한다() {
+        // given
+        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+
+        // when
+        memberRepository.delete(member);
+
+        // then
+        assertThat(memberRepository.findById(member.id())).isEmpty();
+    }
+
+    @Test
+    void 사용자를_입력_받아_삭제할_때_존재하지_않는_사용자여도_예외가_발생하지_않는다() {
+        // expect
+        assertThatNoException().isThrownBy(() -> memberRepository.delete(new Member("", "", KAKAO)));
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
@@ -39,17 +39,4 @@ class MemberRepositoryTest {
         // expect
         assertThat(foundMember).isEmpty();
     }
-
-    @Test
-    void 삭제된_회원을_ID로_조회하면_빈_Optional을_반환한다() {
-        // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-
-        // when
-        memberRepository.deleteById(member.id());
-        Optional<Member> foundMember = memberRepository.findById(member.id());
-
-        // then
-        assertThat(foundMember).isEmpty();
-    }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/member/MemberTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/member/MemberTest.java
@@ -1,14 +1,11 @@
 package dev.tripdraw.domain.member;
 
-import dev.tripdraw.exception.member.MemberException;
+import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-
-import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
-import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -24,29 +21,5 @@ class MemberTest {
 
         // then
         assertThat(member.nickname()).isEqualTo("순후추");
-    }
-
-    @Test
-    void 삭제한다() {
-        // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-
-        // when
-        member.delete();
-
-        // then
-        assertThat(member.isDeleted()).isTrue();
-    }
-
-    @Test
-    void 삭제된_회원을_삭제할_경우_예외를_발생시킨다() {
-        // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        member.delete();
-        
-        // when
-        assertThatThrownBy(member::delete)
-                .isInstanceOf(MemberException.class)
-                .hasMessage(MEMBER_NOT_FOUND.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/post/PostRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/post/PostRepositoryTest.java
@@ -1,0 +1,72 @@
+package dev.tripdraw.domain.post;
+
+import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.domain.trip.Point;
+import dev.tripdraw.domain.trip.Trip;
+import dev.tripdraw.domain.trip.TripName;
+import dev.tripdraw.domain.trip.TripRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+class PostRepositoryTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Trip trip;
+    private Point point;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        trip = tripRepository.save(new Trip(TripName.from("통후추의 여행"), member));
+        point = new Point(3.14, 5.25, LocalDateTime.now());
+        trip.add(point);
+    }
+
+    @Test
+    void 여행_ID로_감상_목록을_조회한다() {
+        // given
+        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member, trip.id());
+        postRepository.save(post);
+
+        // when
+        List<Post> posts = postRepository.findAllByTripId(trip.id());
+
+        // then
+        assertThat(posts).usingRecursiveComparison().isEqualTo(List.of(post));
+    }
+
+    @Test
+    void 회원_ID로_감상을_삭제한다() {
+        // given
+        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member, trip.id());
+        postRepository.save(post);
+
+        // when
+        postRepository.deleteByMemberId(member.id());
+
+        // then
+        assertThat(postRepository.findById(post.id())).isEmpty();
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripRepositoryTest.java
@@ -56,4 +56,17 @@ class TripRepositoryTest {
         // then
         assertThat(trips).hasSize(0);
     }
+
+    @Test
+    void 회원_ID로_여행을_삭제한다() {
+        // given
+        Trip trip = new Trip(TripName.from("제주도 여행"), member);
+        tripRepository.save(trip);
+
+        // when
+        tripRepository.deleteByMemberId(member.id());
+
+        // then
+        assertThat(tripRepository.findById(trip.id())).isEmpty();
+    }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
@@ -144,33 +144,4 @@ class MemberControllerTest extends ControllerTest {
                 .then().log().all()
                 .statusCode(FORBIDDEN.value());
     }
-
-    @Test
-    void code를_입력_받아_사용자를_삭제할_때_존재하지_않는_사용자라면_예외를_발생시킨다() {
-        // given
-        String code = authTokenManager.generate(MIN_VALUE);
-
-        // expect
-        RestAssured.given().log().all()
-                .param("code", code)
-                .when().delete("/members")
-                .then().log().all()
-                .statusCode(NOT_FOUND.value());
-    }
-
-    @Test
-    void code를_입력_받아_사용자를_삭제할_때_이미_삭제된_사용자라면_예외를_발생시킨다() {
-        // given
-        Member member = memberRepository.save(new Member("순후추", "kakaoId", KAKAO));
-        String code = authTokenManager.generate(member.id());
-
-        memberRepository.delete(member);
-
-        // expect
-        RestAssured.given().log().all()
-                .param("code", code)
-                .when().delete("/members")
-                .then().log().all()
-                .statusCode(NOT_FOUND.value());
-    }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/MemberControllerTest.java
@@ -82,7 +82,7 @@ class MemberControllerTest extends ControllerTest {
         Member member = memberRepository.save(new Member("순후추", "kakaoId", KAKAO));
         String code = authTokenManager.generate(member.id());
 
-        memberRepository.deleteById(member.id());
+        memberRepository.delete(member);
 
         // expect
         RestAssured.given().log().all()
@@ -125,7 +125,7 @@ class MemberControllerTest extends ControllerTest {
         Member member = memberRepository.save(new Member("순후추", "kakaoId", KAKAO));
         String code = authTokenManager.generate(member.id());
 
-        memberRepository.deleteById(member.id());
+        memberRepository.delete(member);
 
         // expect
         RestAssured.given().log().all()

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -282,7 +282,6 @@ class TripControllerTest extends ControllerTest {
         PointResponse pointResponse = response.as(PointResponse.class);
 
         RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(huchuToken)
                 .param("tripId", trip.id())
                 .when().delete("/points/{pointId}", pointResponse.pointId())
@@ -290,7 +289,6 @@ class TripControllerTest extends ControllerTest {
 
         // expect
         RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(huchuToken)
                 .param("tripId", trip.id())
                 .when().delete("/points/{pointId}", pointResponse.pointId())
@@ -362,7 +360,6 @@ class TripControllerTest extends ControllerTest {
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(huchuToken)
                 .param("tripId", trip.id())
                 .when().get("/points/{pointId}", pointId)
@@ -386,6 +383,26 @@ class TripControllerTest extends ControllerTest {
         });
     }
 
+    @Test
+    void 여행을_삭제한다() {
+        // expect
+        RestAssured.given().log().all()
+                .auth().preemptive().oauth2(huchuToken)
+                .when().delete("/trips/{tripId}", trip.id())
+                .then().log().all()
+                .statusCode(NO_CONTENT.value());
+    }
+
+    @Test
+    void 여행을_삭제할_때_인증에_실패하면_예외가_발생한다() {
+        // expect
+        RestAssured.given().log().all()
+                .auth().preemptive().oauth2(WRONG_TOKEN)
+                .when().delete("/trips/{tripId}", trip.id())
+                .then().log().all()
+                .statusCode(UNAUTHORIZED.value());
+    }
+
     private PointCreateResponse createPointAndGetId(PointCreateRequest request) {
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
@@ -395,7 +412,6 @@ class TripControllerTest extends ControllerTest {
                 .then().log().all()
                 .extract();
 
-        PointCreateResponse pointCreateResponse = response.as(PointCreateResponse.class);
-        return pointCreateResponse;
+        return response.as(PointCreateResponse.class);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -3,6 +3,7 @@ package dev.tripdraw.presentation.controller;
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
 import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
@@ -292,7 +293,7 @@ class TripControllerTest extends ControllerTest {
                 .param("tripId", trip.id())
                 .when().delete("/points/{pointId}", pointResponse.pointId())
                 .then().log().all()
-                .statusCode(NOT_FOUND.value());
+                .statusCode(CONFLICT.value());
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/TripControllerTest.java
@@ -3,7 +3,6 @@ package dev.tripdraw.presentation.controller;
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
 import static dev.tripdraw.domain.trip.TripStatus.FINISHED;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
@@ -293,7 +292,7 @@ class TripControllerTest extends ControllerTest {
                 .param("tripId", trip.id())
                 .when().delete("/points/{pointId}", pointResponse.pointId())
                 .then().log().all()
-                .statusCode(CONFLICT.value());
+                .statusCode(NOT_FOUND.value());
     }
 
     @Test


### PR DESCRIPTION
### 📌 관련 이슈

- closed #255 

### 📁 작업 설명

- 여행 삭제 기능 추가
- 회원 탈퇴 기능 수정
- 위치 삭제 기능 수정

## 참고

### 회원 삭제(탈퇴)를 soft delete 에서 hard delete 로 수정했습니다.
![image](https://github.com/woowacourse-teams/2023-trip-draw/assets/106813090/19838af6-94e1-404c-8a6f-fd45b1db5de0)

저희의 개인정보 처리방침에 따르면 회원 탈퇴 요청 시 개인정보를 파기해야 합니다. 따라서 soft delete 를 적용하기에 애매합니다. 앱 심사를 앞두고 있으므로 보수적으로 코드를 작성했습니다.

### 여행 삭제를 hard delete로 구현했습니다.
회원 탈퇴 시, 회원의 여행, 감상 등의 데이터가 물리적으로 삭제되어야 합니다.(hard delete) 따라서 회원의 일반적인 여행 삭제 요청에 대해서는 soft delete를 하고, 회원 탈퇴의 경우에만 hard delete를 하는 방법을 구상했습니다. 이를 구현하기 위해 여러가지 시도를 해보았으나 현재의 구조에서는 어렵다는 결론을 내렸습니다. 가장 간단한 방법인 hard delete를 채택했습니다.

### 기타
- 위치 정보 삭제 역시 hard delete 고려 중입니다. 다른 엔티티와 통일성을 맞추기 위함입니다.
- 이전의 코드에서, 위치 정보를 삭제한 후 여행의 경로를 조회하면 삭제된 위치도 함께 조회됩니다.
- 위치 정보 삭제 후, 삭제된 위치가 조회되지 않도록 수정했습니다.