### PR TITLE
[feat] 회원 닉네임 등록 시 중복 검증 추가 (#278)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/AuthService.java
+++ b/backend/src/main/java/dev/tripdraw/application/AuthService.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.application;
 
+import static dev.tripdraw.exception.member.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
-import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
 
 import dev.tripdraw.application.oauth.AuthTokenManager;
 import dev.tripdraw.application.oauth.OauthClient;
@@ -59,16 +59,16 @@ public class AuthService {
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         String nickname = registerRequest.nickname();
-        validateNicknameDuplication(nickname);
+        validateDuplicateNickname(nickname);
         member.changeNickname(nickname);
 
         String accessToken = authTokenManager.generate(member.id());
         return new OauthResponse(accessToken);
     }
 
-    private void validateNicknameDuplication(String nickname) {
+    private void validateDuplicateNickname(String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
-            throw new MemberException(NICKNAME_CONFLICT);
+            throw new MemberException(DUPLICATE_NICKNAME);
         }
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/AuthService.java
+++ b/backend/src/main/java/dev/tripdraw/application/AuthService.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.application;
 
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
 
 import dev.tripdraw.application.oauth.AuthTokenManager;
 import dev.tripdraw.application.oauth.OauthClient;
@@ -57,8 +58,17 @@ public class AuthService {
         Member member = memberRepository.findByOauthIdAndOauthType(oauthInfo.oauthId(), oauthInfo.oauthType())
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
-        member.changeNickname(registerRequest.nickname());
+        String nickname = registerRequest.nickname();
+        validateNicknameDuplication(nickname);
+        member.changeNickname(nickname);
+
         String accessToken = authTokenManager.generate(member.id());
         return new OauthResponse(accessToken);
+    }
+
+    private void validateNicknameDuplication(String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new MemberException(NICKNAME_CONFLICT);
+        }
     }
 }

--- a/backend/src/main/java/dev/tripdraw/application/oauth/AuthTokenManager.java
+++ b/backend/src/main/java/dev/tripdraw/application/oauth/AuthTokenManager.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class AuthTokenManager {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private Long expirationTime;
+    private final Long expirationTime;
 
     public AuthTokenManager(JwtTokenProvider jwtTokenProvider, @Value("${jwt.expiration-time}") Long expirationTime) {
         this.jwtTokenProvider = jwtTokenProvider;

--- a/backend/src/main/java/dev/tripdraw/config/swagger/SwaggerConfig.java
+++ b/backend/src/main/java/dev/tripdraw/config/swagger/SwaggerConfig.java
@@ -11,8 +11,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    private static final String BEARER_TYPE = "bearer";
     static final String BEARER_SECURITY_SCHEME_KEY = "Authorization Bearer";
+    private static final String BEARER_TYPE = "bearer";
+    private static final String TOKEN_SAMPLE = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMzMiLCJleHAiOjE2OTE4OTA0NjZ9.NlzZEEDWdjovafRPCD1ZvddeRUccZfyZpcUWzGPAI4oK-PKyPM64TIMJ3HyOy29vJtg_MET1c4omWUkGOb4qyQ";
 
     @Bean
     public OpenAPI openAPI() {
@@ -37,7 +38,7 @@ public class SwaggerConfig {
                 .type(SecurityScheme.Type.HTTP)
                 .scheme(BEARER_TYPE)
                 .description(
-                        "로그인하고 받은 JWT를 입력해주세요. 예시) eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMzMiLCJleHAiOjE2OTE4OTA0NjZ9.NlzZEEDWdjovafRPCD1ZvddeRUccZfyZpcUWzGPAI4oK-PKyPM64TIMJ3HyOy29vJtg_MET1c4omWUkGOb4qyQ"
+                        "로그인하고 받은 JWT를 입력해주세요. 예시) " + TOKEN_SAMPLE
                 );
     }
 

--- a/backend/src/main/java/dev/tripdraw/domain/member/MemberRepository.java
+++ b/backend/src/main/java/dev/tripdraw/domain/member/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByOauthIdAndOauthType(String oauthId, OauthType oauthType);
+
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/dev/tripdraw/dto/auth/OauthRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/auth/OauthRequest.java
@@ -1,6 +1,16 @@
 package dev.tripdraw.dto.auth;
 
 import dev.tripdraw.domain.oauth.OauthType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record OauthRequest(OauthType oauthType, String oauthToken) {
+public record OauthRequest(
+
+        @Schema(description = "소셜 로그인 타입", example = "KAKAO")
+        OauthType oauthType,
+
+        @Schema(description = "Access Token", example = TOKEN_SAMPLE)
+        String oauthToken
+) {
+
+    private static final String TOKEN_SAMPLE = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMzMiLCJleHAiOjE2OTE4OTA0NjZ9.NlzZEEDWdjovafRPCD1ZvddeRUccZfyZpcUWzGPAI4oK-PKyPM64TIMJ3HyOy29vJtg_MET1c4omWUkGOb4qyQ";
 }

--- a/backend/src/main/java/dev/tripdraw/dto/auth/OauthResponse.java
+++ b/backend/src/main/java/dev/tripdraw/dto/auth/OauthResponse.java
@@ -1,4 +1,11 @@
 package dev.tripdraw.dto.auth;
 
-public record OauthResponse(String accessToken) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OauthResponse(
+        @Schema(description = "Access Token", example = TOKEN_SAMPLE)
+
+        String accessToken
+) {
+    private static final String TOKEN_SAMPLE = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMzMiLCJleHAiOjE2OTE4OTA0NjZ9.NlzZEEDWdjovafRPCD1ZvddeRUccZfyZpcUWzGPAI4oK-PKyPM64TIMJ3HyOy29vJtg_MET1c4omWUkGOb4qyQ";
 }

--- a/backend/src/main/java/dev/tripdraw/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/auth/RegisterRequest.java
@@ -1,6 +1,21 @@
 package dev.tripdraw.dto.auth;
 
 import dev.tripdraw.domain.oauth.OauthType;
+import dev.tripdraw.dto.validation.NoWhiteSpace;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record RegisterRequest(String nickname, OauthType oauthType, String oauthToken) {
+public record RegisterRequest(
+
+        @Schema(description = "등록할 닉네임", example = "통후추")
+        @NoWhiteSpace
+        String nickname,
+
+        @Schema(description = "소셜 로그인 타입", example = "KAKAO")
+        OauthType oauthType,
+
+        @Schema(description = "Access Token", example = TOKEN_SAMPLE)
+        String oauthToken
+) {
+
+    private static final String TOKEN_SAMPLE = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMzMiLCJleHAiOjE2OTE4OTA0NjZ9.NlzZEEDWdjovafRPCD1ZvddeRUccZfyZpcUWzGPAI4oK-PKyPM64TIMJ3HyOy29vJtg_MET1c4omWUkGOb4qyQ";
 }

--- a/backend/src/main/java/dev/tripdraw/exception/member/MemberExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/member/MemberExceptionType.java
@@ -1,13 +1,13 @@
 package dev.tripdraw.exception.member;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import dev.tripdraw.exception.common.ExceptionType;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 public enum MemberExceptionType implements ExceptionType {
-    NICKNAME_CONFLICT(CONFLICT, "이미 존재하는 닉네임입니다."),
+    DUPLICATE_NICKNAME(CONFLICT, "이미 존재하는 닉네임입니다."),
     MEMBER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다."),
     ;
 

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/AuthController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/AuthController.java
@@ -7,6 +7,7 @@ import dev.tripdraw.dto.auth.RegisterRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,7 +40,7 @@ public class AuthController {
             description = "닉네임 등록 성공."
     )
     @PostMapping("/oauth/register")
-    public ResponseEntity<OauthResponse> register(@RequestBody RegisterRequest registerRequest) {
+    public ResponseEntity<OauthResponse> register(@Valid @RequestBody RegisterRequest registerRequest) {
         OauthResponse oauthResponse = authService.register(registerRequest);
         return ResponseEntity.ok(oauthResponse);
     }

--- a/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
@@ -1,8 +1,8 @@
 package dev.tripdraw.application;
 
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
+import static dev.tripdraw.exception.member.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
-import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -93,10 +93,10 @@ class AuthServiceTest {
         // given
         memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
         RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
-        
+
         // expect
         assertThatThrownBy(() -> authService.register(registerRequest))
                 .isInstanceOf(MemberException.class)
-                .hasMessage(NICKNAME_CONFLICT.getMessage());
+                .hasMessage(DUPLICATE_NICKNAME.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
@@ -2,6 +2,7 @@ package dev.tripdraw.application;
 
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.member.MemberExceptionType.NICKNAME_CONFLICT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -85,5 +86,17 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.register(registerRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 신규_회원의_닉네임을_등록할_때_이미_존재하는_닉네임이면_예외가_발생한다() {
+        // given
+        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
+        
+        // expect
+        assertThatThrownBy(() -> authService.register(registerRequest))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(NICKNAME_CONFLICT.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/member/MemberRepositoryTest.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
@@ -38,5 +40,18 @@ class MemberRepositoryTest {
 
         // expect
         assertThat(foundMember).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"통후추, true", "순후추, false"})
+    void 닉네임이_존재하는지_확인한다(String nickname, boolean expected) {
+        // given
+        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+
+        // when
+        boolean actual = memberRepository.existsByNickname(nickname);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
@@ -134,7 +134,7 @@ class AuthControllerTest extends ControllerTest {
     @Test
     void 신규_회원의_닉네임을_등록할_때_이미_존재하는_닉네임이면_예외가_발생한다() {
         // given
-        Member member = memberRepository.save(new Member("중복된 닉네임", "kakaoId", KAKAO));
+        Member member = memberRepository.save(new Member("중복닉네임", "kakaoId", KAKAO));
         RegisterRequest registerRequest = new RegisterRequest(member.nickname(), KAKAO, "oauth.kakao.token");
 
         // when

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package dev.tripdraw.presentation.controller;
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
@@ -137,12 +138,26 @@ class AuthControllerTest extends ControllerTest {
         Member member = memberRepository.save(new Member("중복닉네임", "kakaoId", KAKAO));
         RegisterRequest registerRequest = new RegisterRequest(member.nickname(), KAKAO, "oauth.kakao.token");
 
-        // when
+        // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .body(registerRequest)
                 .when().post("/oauth/register")
                 .then().log().all()
                 .statusCode(CONFLICT.value());
+    }
+
+    @Test
+    void 신규_회원의_닉네임을_등록할_때_닉네임에_공백이_있으면_예외가_발생한다() {
+        // given
+        RegisterRequest registerRequest = new RegisterRequest("공  백", KAKAO, "oauth.kakao.token");
+
+        // expect
+        RestAssured.given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .body(registerRequest)
+                .when().post("/oauth/register")
+                .then().log().all()
+                .statusCode(BAD_REQUEST.value());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
@@ -22,6 +22,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -48,116 +49,124 @@ class AuthControllerTest extends ControllerTest {
                 .thenReturn(new TestKakaoApiClient());
     }
 
-    @Test
-    void 가입된_회원이_카카오_소셜_로그인하면_토큰이_포함된_응답을_반환한다() {
-        // given
-        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+    @Nested
+    class 로그인할_때 {
 
-        // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .body(oauthRequest)
-                .when().post("/oauth/login")
-                .then().log().all()
-                .extract();
+        @Test
+        void 가입된_회원이면_토큰이_포함된_응답을_반환한다() {
+            // given
+            memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+            OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
 
-        // then
-        OauthResponse oauthResponse = response.as(OauthResponse.class);
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(oauthRequest)
+                    .when().post("/oauth/login")
+                    .then().log().all()
+                    .extract();
 
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(oauthResponse.accessToken()).isNotNull();
-        });
+            // then
+            OauthResponse oauthResponse = response.as(OauthResponse.class);
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+                softly.assertThat(oauthResponse.accessToken()).isNotNull();
+            });
+        }
+
+        @Test
+        void 신규_회원이면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
+            // given
+            OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(oauthRequest)
+                    .when().post("/oauth/login")
+                    .then().log().all()
+                    .extract();
+
+            // then
+            OauthResponse oauthResponse = response.as(OauthResponse.class);
+
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+                softly.assertThat(oauthResponse.accessToken()).isEmpty();
+            });
+        }
     }
 
-    @Test
-    void 신규_회원이_로그인하면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
-        // given
-        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+    @Nested
+    class 신규_회원의_닉네임을_등록할_때 {
 
-        // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .body(oauthRequest)
-                .when().post("/oauth/login")
-                .then().log().all()
-                .extract();
+        @Test
+        void 정상_등록하면_토큰이_포함된_응답을_반환한다() {
+            // given
+            Member member = Member.of("kakaoId", KAKAO);
+            memberRepository.save(member);
 
-        // then
-        OauthResponse oauthResponse = response.as(OauthResponse.class);
+            RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
 
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(oauthResponse.accessToken()).isEmpty();
-        });
-    }
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(registerRequest)
+                    .when().post("/oauth/register")
+                    .then().log().all()
+                    .extract();
 
-    @Test
-    void 신규_회원의_닉네임을_등록하면_토큰이_포함된_응답을_반환한다() {
-        // given
-        Member member = Member.of("kakaoId", KAKAO);
-        memberRepository.save(member);
+            // then
+            OauthResponse oauthResponse = response.as(OauthResponse.class);
 
-        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+                softly.assertThat(oauthResponse.accessToken()).isNotEmpty();
+            });
+        }
 
-        // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .body(registerRequest)
-                .when().post("/oauth/register")
-                .then().log().all()
-                .extract();
+        @Test
+        void 회원이_존재하지_않으면_예외가_발생한다() {
+            // given
+            RegisterRequest registerRequest = new RegisterRequest("저장안된후추", KAKAO, "oauth.kakao.token");
 
-        // then
-        OauthResponse oauthResponse = response.as(OauthResponse.class);
+            // expect
+            RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(registerRequest)
+                    .when().post("/oauth/register")
+                    .then().log().all()
+                    .statusCode(NOT_FOUND.value());
+        }
 
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(oauthResponse.accessToken()).isNotEmpty();
-        });
-    }
+        @Test
+        void 이미_존재하는_닉네임이면_예외가_발생한다() {
+            // given
+            Member member = memberRepository.save(new Member("중복닉네임", "kakaoId", KAKAO));
+            RegisterRequest registerRequest = new RegisterRequest(member.nickname(), KAKAO, "oauth.kakao.token");
 
-    @Test
-    void 신규_회원의_닉네임을_등록할_때_회원이_존재하지_않으면_예외가_발생한다() {
-        // given
-        RegisterRequest registerRequest = new RegisterRequest("저장안된후추", KAKAO, "oauth.kakao.token");
+            // expect
+            RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(registerRequest)
+                    .when().post("/oauth/register")
+                    .then().log().all()
+                    .statusCode(CONFLICT.value());
+        }
 
-        // expect
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .body(registerRequest)
-                .when().post("/oauth/register")
-                .then().log().all()
-                .statusCode(NOT_FOUND.value());
-    }
+        @Test
+        void 닉네임에_공백이_있으면_예외가_발생한다() {
+            // given
+            RegisterRequest registerRequest = new RegisterRequest("공  백", KAKAO, "oauth.kakao.token");
 
-    @Test
-    void 신규_회원의_닉네임을_등록할_때_이미_존재하는_닉네임이면_예외가_발생한다() {
-        // given
-        Member member = memberRepository.save(new Member("중복닉네임", "kakaoId", KAKAO));
-        RegisterRequest registerRequest = new RegisterRequest(member.nickname(), KAKAO, "oauth.kakao.token");
-
-        // expect
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .body(registerRequest)
-                .when().post("/oauth/register")
-                .then().log().all()
-                .statusCode(CONFLICT.value());
-    }
-
-    @Test
-    void 신규_회원의_닉네임을_등록할_때_닉네임에_공백이_있으면_예외가_발생한다() {
-        // given
-        RegisterRequest registerRequest = new RegisterRequest("공  백", KAKAO, "oauth.kakao.token");
-
-        // expect
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .body(registerRequest)
-                .when().post("/oauth/register")
-                .then().log().all()
-                .statusCode(BAD_REQUEST.value());
+            // expect
+            RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(registerRequest)
+                    .when().post("/oauth/register")
+                    .then().log().all()
+                    .statusCode(BAD_REQUEST.value());
+        }
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #278 

### 📁 작업 설명

- 회원 닉네임 등록 시 중복 검증을 추가했습니다.

### 참고
두 가지 선택지를 고려했습니다.

1. 전체 회원의 이름 목록을 불러와서 Member.changeName() 메서드의 파라미터로 전달한 후, Member.changeName() 메서드 내에서 검증하는 방법
2. MemberRepository.existsByNickname()  메서드로 존재 여부만 확인한 후 검증하는 방법

이 중에 첫번째 방법은 회원의 수가 많아질수록 "데이터 조회 시간" + "중복 검사 시간"이 늘어날 것으로 예상했습니다. 따라서 두 번째 방법을 택했습니다. 자세한 내용은 아래와 같습니다.

memberRepository에 `existsByNickname` 메서드를 추가했습니다.
```java
public interface MemberRepository extends JpaRepository<Member, Long> {

    boolean existsByNickname(String nickname);
}
```

authService에서 이 메서드를 활용합니다.

```java
@Transactional
@Service
public class AuthService {

    // (...)
    public OauthResponse register(RegisterRequest registerRequest) {
        OauthClient oauthClient = oauthClientProvider.provide(registerRequest.oauthType());
        OauthInfo oauthInfo = oauthClient.requestOauthInfo(registerRequest.oauthToken());

        Member member = memberRepository.findByOauthIdAndOauthType(oauthInfo.oauthId(), oauthInfo.oauthType())
                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));

        String nickname = registerRequest.nickname();
        validateNicknameDuplication(nickname);
        member.changeNickname(nickname);

        String accessToken = authTokenManager.generate(member.id());
        return new OauthResponse(accessToken);
    }

    private void validateNicknameDuplication(String nickname) {
        if (memberRepository.existsByNickname(nickname)) {
            throw new MemberException(NICKNAME_CONFLICT);
        }
    }
}
```

더 좋은 방법 있으면 알려주세요!