### PR TITLE
[feat] AccessToken 갱신 기능을 구현한다 (#292)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/AuthService.java
+++ b/backend/src/main/java/dev/tripdraw/application/AuthService.java
@@ -8,6 +8,7 @@ import dev.tripdraw.application.oauth.OauthClient;
 import dev.tripdraw.application.oauth.OauthClientProvider;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.dto.auth.AccessTokenRefreshRequest;
 import dev.tripdraw.dto.auth.OauthInfo;
 import dev.tripdraw.dto.auth.OauthRequest;
 import dev.tripdraw.dto.auth.OauthResponse;
@@ -70,5 +71,10 @@ public class AuthService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new MemberException(DUPLICATE_NICKNAME);
         }
+    }
+
+    public OauthResponse refresh(AccessTokenRefreshRequest accessTokenRefreshRequest) {
+        Long memberId = authTokenManager.extractMemberId(accessTokenRefreshRequest.accessToken());
+        return new OauthResponse(authTokenManager.generate(memberId));
     }
 }

--- a/backend/src/main/java/dev/tripdraw/dto/auth/AccessTokenRefreshRequest.java
+++ b/backend/src/main/java/dev/tripdraw/dto/auth/AccessTokenRefreshRequest.java
@@ -1,0 +1,4 @@
+package dev.tripdraw.dto.auth;
+
+public record AccessTokenRefreshRequest(String accessToken) {
+}

--- a/backend/src/main/java/dev/tripdraw/presentation/controller/AuthController.java
+++ b/backend/src/main/java/dev/tripdraw/presentation/controller/AuthController.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.presentation.controller;
 
 import dev.tripdraw.application.AuthService;
+import dev.tripdraw.dto.auth.AccessTokenRefreshRequest;
 import dev.tripdraw.dto.auth.OauthRequest;
 import dev.tripdraw.dto.auth.OauthResponse;
 import dev.tripdraw.dto.auth.RegisterRequest;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,6 +44,17 @@ public class AuthController {
     @PostMapping("/oauth/register")
     public ResponseEntity<OauthResponse> register(@Valid @RequestBody RegisterRequest registerRequest) {
         OauthResponse oauthResponse = authService.register(registerRequest);
+        return ResponseEntity.ok(oauthResponse);
+    }
+
+    @Operation(summary = "Access Token 갱신 API", description = "액세스 토큰을 갱신합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "액세스 토큰 갱신 성공."
+    )
+    @GetMapping("/oauth/refresh")
+    public ResponseEntity<OauthResponse> refresh(@RequestBody AccessTokenRefreshRequest accessTokenRefreshRequest) {
+        OauthResponse oauthResponse = authService.refresh(accessTokenRefreshRequest);
         return ResponseEntity.ok(oauthResponse);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
@@ -1,6 +1,8 @@
 package dev.tripdraw.application;
 
 import static dev.tripdraw.domain.oauth.OauthType.KAKAO;
+import static dev.tripdraw.exception.auth.AuthExceptionType.EXPIRED_TOKEN;
+import static dev.tripdraw.exception.auth.AuthExceptionType.INVALID_TOKEN;
 import static dev.tripdraw.exception.member.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,33 +10,53 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import dev.tripdraw.application.oauth.OauthClientProvider;
+import dev.tripdraw.aspect.TimeTravelToFutureWhenRefreshAspect;
+import dev.tripdraw.aspect.TimeTravelToPastWhenLogInAspect;
 import dev.tripdraw.common.TestKakaoApiClient;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.dto.auth.AccessTokenRefreshRequest;
 import dev.tripdraw.dto.auth.OauthRequest;
 import dev.tripdraw.dto.auth.OauthResponse;
 import dev.tripdraw.dto.auth.RegisterRequest;
+import dev.tripdraw.exception.auth.AuthException;
 import dev.tripdraw.exception.member.MemberException;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 
+@ComponentScan(basePackages = "dev.tripdraw.aspect")
 @ServiceTest
 class AuthServiceTest {
-
-    @Autowired
-    private AuthService authService;
 
     @MockBean
     OauthClientProvider oauthClientProvider;
 
     @Autowired
+    private AuthService authService;
+
+    @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private TimeTravelToPastWhenLogInAspect timeTravelToPastWhenLogInAspect;
+
+    @Autowired
+    private TimeTravelToFutureWhenRefreshAspect timeTravelToFutureWhenRefreshAspect;
 
     @BeforeEach
     void setUp() {
         when(oauthClientProvider.provide(KAKAO)).thenReturn(new TestKakaoApiClient());
+    }
+
+    @AfterEach
+    void clear() {
+        timeTravelToPastWhenLogInAspect.setCustomTime(null);
+        timeTravelToFutureWhenRefreshAspect.setCustomTime(null);
     }
 
     @Test
@@ -98,5 +120,51 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.register(registerRequest))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(DUPLICATE_NICKNAME.getMessage());
+    }
+
+    @Test
+    void 토큰이_유효하면_액세스_토큰을_갱신한다() {
+        // given
+        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        OauthResponse oauthResponse = authService.login(new OauthRequest(KAKAO, "oauth.kakao.token"));
+        String validToken = oauthResponse.accessToken();
+        AccessTokenRefreshRequest accessTokenRefreshRequest = new AccessTokenRefreshRequest(validToken);
+
+        // when
+        timeTravelToFutureWhenRefreshAspect.setCustomTime("A few seconds later...");
+        OauthResponse oauthResponseWithNewAccessToken = authService.refresh(accessTokenRefreshRequest);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(oauthResponseWithNewAccessToken.accessToken()).isNotEmpty();
+            softly.assertThat(validToken).isNotEqualTo(oauthResponseWithNewAccessToken.accessToken());
+        });
+    }
+
+    @Test
+    void 액세스_토큰_갱신_시에_유효하지_않은_토큰이면_예외를_반환한다() {
+        // given
+        AccessTokenRefreshRequest refreshRequestWithInvalidToken = new AccessTokenRefreshRequest(
+                "It.is.InvalidToken");
+
+        // expect
+        assertThatThrownBy(() -> authService.refresh(refreshRequestWithInvalidToken))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void 액세스_토큰_갱신_시에_만료된_토큰이면_예외를_반환한다() {
+        // given
+        timeTravelToPastWhenLogInAspect.setCustomTime("호랑이 담배 피던 시절...");
+        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        OauthResponse oauthResponse = authService.login(new OauthRequest(KAKAO, "oauth.kakao.token"));
+        String expiredToken = oauthResponse.accessToken();
+        AccessTokenRefreshRequest expiredAccessTokenRefreshRequest = new AccessTokenRefreshRequest(expiredToken);
+
+        // expect
+        assertThatThrownBy(() -> authService.refresh(expiredAccessTokenRefreshRequest))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(EXPIRED_TOKEN.getMessage());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/AuthServiceTest.java
@@ -55,8 +55,8 @@ class AuthServiceTest {
 
     @AfterEach
     void clear() {
-        timeTravelToPastWhenLogInAspect.setCustomTime(null);
-        timeTravelToFutureWhenRefreshAspect.setCustomTime(null);
+        timeTravelToPastWhenLogInAspect.timeTravelTo(null);
+        timeTravelToFutureWhenRefreshAspect.timeTravelTo(null);
     }
 
     @Test
@@ -131,7 +131,7 @@ class AuthServiceTest {
         AccessTokenRefreshRequest accessTokenRefreshRequest = new AccessTokenRefreshRequest(validToken);
 
         // when
-        timeTravelToFutureWhenRefreshAspect.setCustomTime("A few seconds later...");
+        timeTravelToFutureWhenRefreshAspect.timeTravelTo("A few seconds later...");
         OauthResponse oauthResponseWithNewAccessToken = authService.refresh(accessTokenRefreshRequest);
 
         // then
@@ -156,7 +156,7 @@ class AuthServiceTest {
     @Test
     void 액세스_토큰_갱신_시에_만료된_토큰이면_예외를_반환한다() {
         // given
-        timeTravelToPastWhenLogInAspect.setCustomTime("호랑이 담배 피던 시절...");
+        timeTravelToPastWhenLogInAspect.timeTravelTo("호랑이 담배 피던 시절...");
         memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
         OauthResponse oauthResponse = authService.login(new OauthRequest(KAKAO, "oauth.kakao.token"));
         String expiredToken = oauthResponse.accessToken();

--- a/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToFutureWhenRefreshAspect.java
+++ b/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToFutureWhenRefreshAspect.java
@@ -1,0 +1,55 @@
+package dev.tripdraw.aspect;
+
+import dev.tripdraw.application.oauth.AuthTokenManager;
+import dev.tripdraw.application.oauth.JwtTokenProvider;
+import dev.tripdraw.dto.auth.AccessTokenRefreshRequest;
+import dev.tripdraw.dto.auth.OauthResponse;
+import java.sql.Date;
+import java.time.Instant;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class TimeTravelToFutureWhenRefreshAspect {
+
+    @Autowired
+    AuthTokenManager authTokenManager;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    private String customTime;
+
+    public void setCustomTime(String customTime) {
+        this.customTime = customTime;
+    }
+
+    @Around("execution(* dev.tripdraw.application.AuthService.refresh(..))")
+    public Object manipulateTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        if (customTime != null) {
+            AccessTokenRefreshRequest request = (AccessTokenRefreshRequest) joinPoint.getArgs()[0];
+            Long memberId = authTokenManager.extractMemberId(request.accessToken());
+
+            Instant manipulatedExpirationTime = Instant.now().plusSeconds(60);
+            String newAccessToken = jwtTokenProvider.generate(
+                    String.valueOf(memberId),
+                    Date.from(manipulatedExpirationTime)
+            );
+
+            OauthResponse manipulatedResponse = new OauthResponse(newAccessToken);
+
+            Object originalResponse = joinPoint.proceed();
+            if (originalResponse instanceof OauthResponse) {
+                return manipulatedResponse;
+            } else {
+                return originalResponse;
+            }
+        }
+
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToFutureWhenRefreshAspect.java
+++ b/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToFutureWhenRefreshAspect.java
@@ -24,7 +24,7 @@ public class TimeTravelToFutureWhenRefreshAspect {
 
     private String customTime;
 
-    public void setCustomTime(String customTime) {
+    public void timeTravelTo(String customTime) {
         this.customTime = customTime;
     }
 

--- a/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToPastWhenLogInAspect.java
+++ b/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToPastWhenLogInAspect.java
@@ -1,0 +1,75 @@
+package dev.tripdraw.aspect;
+
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+
+import dev.tripdraw.application.oauth.AuthTokenManager;
+import dev.tripdraw.application.oauth.JwtTokenProvider;
+import dev.tripdraw.application.oauth.OauthClient;
+import dev.tripdraw.application.oauth.OauthClientProvider;
+import dev.tripdraw.domain.member.Member;
+import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.dto.auth.OauthInfo;
+import dev.tripdraw.dto.auth.OauthRequest;
+import dev.tripdraw.dto.auth.OauthResponse;
+import dev.tripdraw.exception.member.MemberException;
+import java.sql.Date;
+import java.time.Instant;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class TimeTravelToPastWhenLogInAspect {
+
+    @Autowired
+    AuthTokenManager authTokenManager;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    private String customTime;
+    private final OauthClientProvider oauthClientProvider;
+
+    public TimeTravelToPastWhenLogInAspect(OauthClientProvider oauthClientProvider) {
+        this.oauthClientProvider = oauthClientProvider;
+    }
+
+    public void setCustomTime(String customTime) {
+        this.customTime = customTime;
+    }
+
+    @Around("execution(* dev.tripdraw.application.AuthService.login(..))")
+    public Object manipulateTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        if (customTime != null) {
+            OauthRequest request = (OauthRequest) joinPoint.getArgs()[0];
+            OauthClient oauthClient = oauthClientProvider.provide(request.oauthType());
+            OauthInfo oauthInfo = oauthClient.requestOauthInfo(request.oauthToken());
+
+            Member member = memberRepository.findByOauthIdAndOauthType(oauthInfo.oauthId(), oauthInfo.oauthType())
+                    .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+            Instant manipulatedExpirationTime = Instant.EPOCH;
+            String newAccessToken = jwtTokenProvider.generate(
+                    String.valueOf(member.id()),
+                    Date.from(manipulatedExpirationTime)
+            );
+
+            OauthResponse manipulatedResponse = new OauthResponse(newAccessToken);
+
+            Object originalResponse = joinPoint.proceed();
+            if (originalResponse instanceof OauthResponse) {
+                return manipulatedResponse;
+            } else {
+                return originalResponse;
+            }
+        }
+
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToPastWhenLogInAspect.java
+++ b/backend/src/test/java/dev/tripdraw/aspect/TimeTravelToPastWhenLogInAspect.java
@@ -40,7 +40,7 @@ public class TimeTravelToPastWhenLogInAspect {
         this.oauthClientProvider = oauthClientProvider;
     }
 
-    public void setCustomTime(String customTime) {
+    public void timeTravelTo(String customTime) {
         this.customTime = customTime;
     }
 

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
@@ -64,8 +64,8 @@ class AuthControllerTest extends ControllerTest {
 
     @AfterEach
     void clear() {
-        timeTravelToPastWhenLogInAspect.setCustomTime(null);
-        timeTravelToFutureWhenRefreshAspect.setCustomTime(null);
+        timeTravelToPastWhenLogInAspect.timeTravelTo(null);
+        timeTravelToFutureWhenRefreshAspect.timeTravelTo(null);
     }
 
     @Nested
@@ -210,7 +210,7 @@ class AuthControllerTest extends ControllerTest {
             AccessTokenRefreshRequest accessTokenRefreshRequest = new AccessTokenRefreshRequest(validAccessToken);
 
             // when
-            timeTravelToFutureWhenRefreshAspect.setCustomTime("A few moments later...");
+            timeTravelToFutureWhenRefreshAspect.timeTravelTo("A few moments later...");
             ExtractableResponse<Response> refreshResponse = RestAssured.given().log().all()
                     .contentType(APPLICATION_JSON_VALUE)
                     .body(accessTokenRefreshRequest)
@@ -245,7 +245,7 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 만료된_액세스_토큰이면_예외가_발생한다() {
             // given
-            timeTravelToPastWhenLogInAspect.setCustomTime("아주 아주 먼 옛날...");
+            timeTravelToPastWhenLogInAspect.timeTravelTo("아주 아주 먼 옛날...");
             memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
             OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
 

--- a/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/presentation/controller/AuthControllerTest.java
@@ -7,18 +7,23 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import dev.tripdraw.application.oauth.OauthClientProvider;
+import dev.tripdraw.aspect.TimeTravelToFutureWhenRefreshAspect;
+import dev.tripdraw.aspect.TimeTravelToPastWhenLogInAspect;
 import dev.tripdraw.common.TestKakaoApiClient;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
+import dev.tripdraw.dto.auth.AccessTokenRefreshRequest;
 import dev.tripdraw.dto.auth.OauthRequest;
 import dev.tripdraw.dto.auth.OauthResponse;
 import dev.tripdraw.dto.auth.RegisterRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -27,9 +32,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.ComponentScan;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ComponentScan(basePackages = "dev.tripdraw.aspect")
 class AuthControllerTest extends ControllerTest {
 
     @LocalServerPort
@@ -41,12 +48,24 @@ class AuthControllerTest extends ControllerTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    TimeTravelToPastWhenLogInAspect timeTravelToPastWhenLogInAspect;
+
+    @Autowired
+    TimeTravelToFutureWhenRefreshAspect timeTravelToFutureWhenRefreshAspect;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
 
         when(oauthClientProvider.provide(KAKAO))
                 .thenReturn(new TestKakaoApiClient());
+    }
+
+    @AfterEach
+    void clear() {
+        timeTravelToPastWhenLogInAspect.setCustomTime(null);
+        timeTravelToFutureWhenRefreshAspect.setCustomTime(null);
     }
 
     @Nested
@@ -167,6 +186,87 @@ class AuthControllerTest extends ControllerTest {
                     .when().post("/oauth/register")
                     .then().log().all()
                     .statusCode(BAD_REQUEST.value());
+        }
+    }
+
+    @Nested
+    class 액세스_토큰을_갱신할_때 {
+
+        @Test
+        void 액세스_토큰이_유효하면_갱신한다() throws InterruptedException {
+            // given
+            memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+            OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(oauthRequest)
+                    .when().post("/oauth/login")
+                    .then().log().all()
+                    .extract();
+
+            OauthResponse oauthResponse = response.as(OauthResponse.class);
+            String validAccessToken = oauthResponse.accessToken();
+            AccessTokenRefreshRequest accessTokenRefreshRequest = new AccessTokenRefreshRequest(validAccessToken);
+
+            // when
+            timeTravelToFutureWhenRefreshAspect.setCustomTime("A few moments later...");
+            ExtractableResponse<Response> refreshResponse = RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(accessTokenRefreshRequest)
+                    .when().get("/oauth/refresh")
+                    .then().log().all()
+                    .extract();
+            OauthResponse newOauthResponse = refreshResponse.as(OauthResponse.class);
+            String refreshedAccessToken = newOauthResponse.accessToken();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(refreshResponse.statusCode()).isEqualTo(OK.value());
+                softly.assertThat(validAccessToken).isNotEqualTo(refreshedAccessToken);
+            });
+        }
+
+        @Test
+        void 액세스_토큰이_유효하지_않으면_예외가_발생한다() {
+            // given
+            AccessTokenRefreshRequest refreshRequestWithInvalidToken = new AccessTokenRefreshRequest(
+                    "It.is.InvalidToken");
+
+            // expect
+            RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(refreshRequestWithInvalidToken)
+                    .when().get("/oauth/refresh")
+                    .then().log().all()
+                    .statusCode(UNAUTHORIZED.value());
+        }
+
+        @Test
+        void 만료된_액세스_토큰이면_예외가_발생한다() {
+            // given
+            timeTravelToPastWhenLogInAspect.setCustomTime("아주 아주 먼 옛날...");
+            memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+            OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(oauthRequest)
+                    .when().post("/oauth/login")
+                    .then().log().all()
+                    .extract();
+
+            OauthResponse oauthResponse = response.as(OauthResponse.class);
+            String expiredToken = oauthResponse.accessToken();
+            AccessTokenRefreshRequest refreshRequestWithExpiredToken = new AccessTokenRefreshRequest(expiredToken);
+
+            // expect
+            RestAssured.given().log().all()
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .body(refreshRequestWithExpiredToken)
+                    .when().get("/oauth/refresh")
+                    .then().log().all()
+                    .statusCode(UNAUTHORIZED.value());
         }
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #292 

### 📁 작업 설명

## 테스트 코드 메서드 내에서 시간을 흐르게 하는 방법

Access Token을 갱신하는 기능을 구현했습니다.

해당 기능은 다음과 같은 로직으로 동작합니다.

1. 토큰이 유효한지를 확인함 -> 유효하지 않다면 예외를 반환 -> 클라에서 다시 로그인 요청
2. 토큰이 만료되었는지를 확인함 -> 만료되었다면 예외를 반환 -> 클라에서 다시 로그인 요청
3. 토큰의 소유자를 확인함 -> 확인이 된다면 새로운 토큰을 발급해 줌

간단한 로직이지만, 테스트 시에 문제가 되는 부분이 있었습니다.
1. 만료된 토큰을 만드는 것
2. 토큰의 생성 이후, 다시 토큰을 재발급하려면 "1초라도" 시간이 지나야한다는 것

해당 문제를 해결하기 위해 처음에는 Thread.sleep() 메서드를 사용했습니다.

<img width="827" alt="image" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/89302528/f80ae964-588f-466a-9874-0086a7dc097a">

그러나 해당 방법으로는 테스트를 실행할 때 실제로 지정한 시간만큼 쓰레드가 멈추게 됩니다.

적절하지 않다고 판단하여 방법을 찾아봤습니다.

# 1. Clock 클래스 사용
Java 내장 라이브러리의 Clock 클래스를 사용하고,
AccessTokenManager에서 expirationTime을 설정할 때 Date 클래스가 아닌, 이 Clock 클래스를 이용하여 사용을 하면
테스트 시에 mocking이 가능해지는 장점이 있었습니다.
하지만 이는 비즈니스 로직을 변경해야하는 단점이 존재했습니다.

# 2. Spring AOP 사용
Spring AOP에서 제공하는 @Aspect 어노테이션을 이용하여, 특정 메서드와 관련하여 실행 전, 실행 후, 혹은 메서드를 감싸서 실행되는 다른 메서드를 설정할 수 있습니다.

그래서 AuthService 클래스의 login() 메서드와, refresh() 메서드를 @Around 어노테이션을 이용하여 시간을 조정하여 토큰을 발급하도록 했습니다.

```java
@Aspect
@Component
public class TimeTravelToFutureWhenRefreshAspect {

    // ...

    @Around("execution(* dev.tripdraw.application.AuthService.refresh(..))")
    public Object manipulateTime(ProceedingJoinPoint joinPoint) throws Throwable {
        if (customTime != null) {
            AccessTokenRefreshRequest request = (AccessTokenRefreshRequest) joinPoint.getArgs()[0];
            Long memberId = authTokenManager.extractMemberId(request.accessToken());

            Instant manipulatedExpirationTime = Instant.now().plusSeconds(60);
            String newAccessToken = jwtTokenProvider.generate(
                    String.valueOf(memberId),
                    Date.from(manipulatedExpirationTime)
            );

            OauthResponse manipulatedResponse = new OauthResponse(newAccessToken);

            Object originalResponse = joinPoint.proceed();
            if (originalResponse instanceof OauthResponse) {
                return manipulatedResponse;
            } else {
                return originalResponse;
            }
        }

        return joinPoint.proceed();
    }
}
```

```java
@Aspect
@Component
public class TimeTravelToPastWhenLogInAspect {

    // ...

    @Around("execution(* dev.tripdraw.application.AuthService.login(..))")
    public Object manipulateTime(ProceedingJoinPoint joinPoint) throws Throwable {
        if (customTime != null) {
            OauthRequest request = (OauthRequest) joinPoint.getArgs()[0];
            OauthClient oauthClient = oauthClientProvider.provide(request.oauthType());
            OauthInfo oauthInfo = oauthClient.requestOauthInfo(request.oauthToken());

            Member member = memberRepository.findByOauthIdAndOauthType(oauthInfo.oauthId(), oauthInfo.oauthType())
                    .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));

            Instant manipulatedExpirationTime = Instant.EPOCH;
            String newAccessToken = jwtTokenProvider.generate(
                    String.valueOf(member.id()),
                    Date.from(manipulatedExpirationTime)
            );

            OauthResponse manipulatedResponse = new OauthResponse(newAccessToken);

            Object originalResponse = joinPoint.proceed();
            if (originalResponse instanceof OauthResponse) {
                return manipulatedResponse;
            } else {
                return originalResponse;
            }
        }

        return joinPoint.proceed();
    }
}
```

위의 두 클래스를 통해 AOP로 각 메서드의 실행 시에 시간을 조작하여 그 시간에 해당하는 토큰을 발급하도록 했습니다.

```java
@SuppressWarnings("NonAsciiCharacters")
@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@ComponentScan(basePackages = "dev.tripdraw.aspect")
class AuthControllerTest extends ControllerTest {
    
    // ...

        @Test
        void 액세스_토큰이_유효하면_갱신한다() throws InterruptedException {
            
            // ...
            
            // when
            timeTravelToFutureWhenRefreshAspect.timeTravelTo("A few moments later...");
            ExtractableResponse<Response> refreshResponse = RestAssured.given().log().all()
                    .contentType(APPLICATION_JSON_VALUE)
                    .body(accessTokenRefreshRequest)
                    .when().get("/oauth/refresh")
                    .then().log().all()
                    .extract();
            OauthResponse newOauthResponse = refreshResponse.as(OauthResponse.class);
            String refreshedAccessToken = newOauthResponse.accessToken();

            // ...
            }
}
```

AuthControlleTest, AuthServiceTest 두 곳에서 위와 같은 방법으로 시간을 조작하여 테스트를 진행했습니다.

해당 방법을 사용하는 경우,
테스트 코드 내에서 시간이 조작되었음을 명확하게 알 수 없다는 단점이 있습니다.

## 선택
thread를 멈추게 하는 방법은 추후 리프레쉬 토큰을 도입할 때, 실제로 만료된 토큰을 사용해야 하기 때문에 
추후 테스트를 작성할 때 우리가 지정한 만료기간만큼 실제로 thread가 멈춰있어야 하는 문제가 생깁니다.

Clock 클래스를 사용할 수 있으나, 이번에는 비즈니스 로직을 변경하지 않으려고 선택하지 않았습니다.

그래서 Spring AOP를 사용하여 테스트를 진행했습니다.

## 단점 보완
위에 언급했듯이, Spring AOP를 사용하여 테스트를 작성하니 각 메서드에서 시간이 조작되었음을 명확히 알 수 있는 방법이 없었습니다.
그래서 아래와 같은 방법으로 조금이나마 보완했습니다.

각 aspect에서 로직을 진행할 때 customTime이 null이 아닌 경우, 로직이 실행됩니다.
즉, aspect.setCustomTime()의 인자로는 사실 아무 String 값이나 들어가도 실행이 됩니다.

그래서 시간 조정이 필요한 부분에 aspect의 customTime을 변경하고, 그 인자로 시간이 흘렀음을 알려주는 문구를 넣어서 단점을 보완하려 했습니다.