### PR TITLE
[feat] 여행의 총 시간과 거리를 계산한다 (#289)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/application/TripService.java
@@ -3,6 +3,7 @@ package dev.tripdraw.application;
 import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 
+import dev.tripdraw.application.draw.RouteImageGenerator;
 import dev.tripdraw.domain.member.Member;
 import dev.tripdraw.domain.member.MemberRepository;
 import dev.tripdraw.domain.trip.Point;
@@ -24,6 +25,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static dev.tripdraw.exception.member.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Transactional

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
@@ -47,4 +47,10 @@ public class Route {
 
         pointToDelete.delete();
     }
+
+    public List<Point> points() {
+        return points.stream()
+                .filter(point -> !point.isDeleted())
+                .toList();
+    }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Route.java
@@ -11,12 +11,19 @@ import dev.tripdraw.exception.trip.TripException;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
+import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.FetchType.LAZY;
 
 @Accessors(fluent = true)
 @Getter
@@ -52,5 +59,9 @@ public class Route {
         return points.stream()
                 .filter(point -> !point.isDeleted())
                 .toList();
+    }
+
+    public RouteLength calculateRouteLength() {
+        return RouteLength.from(points);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/domain/trip/RouteLength.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/RouteLength.java
@@ -1,0 +1,49 @@
+package dev.tripdraw.domain.trip;
+
+import dev.tripdraw.exception.trip.TripException;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static dev.tripdraw.exception.trip.TripExceptionType.ONE_OR_NO_POINT;
+import static java.lang.Math.*;
+
+public class RouteLength {
+
+    public static final double AVERAGE_DISTANCE_FOR_ONE_DEGREE_DIFFERENCE_IN_LATITUDE_ON_KOREA_REGION = 111.1;
+
+    private final Double length;
+
+    private RouteLength(List<Point> points) {
+        this.length = calculateLength(points);
+    }
+
+    public static RouteLength from(List<Point> points) {
+        return new RouteLength(points);
+    }
+
+    private Double calculateLength(List<Point> points) {
+        if (points.isEmpty() || points.size() == 1) {
+            throw new TripException(ONE_OR_NO_POINT);
+        }
+
+        return IntStream.range(0, points.size() - 1)
+                .mapToDouble(i -> distanceBetween(points.get(i), points.get(i + 1)))
+                .sum();
+    }
+
+    private Double distanceBetween(Point startPoint, Point endPoint) {
+        double theta = startPoint.longitude() - endPoint.longitude();
+        Double latitude1 = startPoint.latitude();
+        Double latitude2 = endPoint.latitude();
+
+        double unitDistance = sin(toRadians(latitude1)) * sin(toRadians(latitude2))
+                + cos(toRadians(latitude1)) * cos(toRadians(latitude2)) * cos(toRadians(theta));
+
+        return toDegrees(acos(unitDistance)) * AVERAGE_DISTANCE_FOR_ONE_DEGREE_DIFFERENCE_IN_LATITUDE_ON_KOREA_REGION;
+    }
+
+    public String lengthInKm() {
+        return String.format("%.2f" + "km", length);
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -152,9 +152,7 @@ public class Trip extends BaseEntity {
     }
 
     public List<Point> points() {
-        return route.points().stream()
-                .filter(point -> !point.isDeleted())
-                .toList();
+        return route.points();
     }
 
     public String nameValue() {

--- a/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/Trip.java
@@ -2,6 +2,7 @@ package dev.tripdraw.domain.trip;
 
 import static dev.tripdraw.domain.trip.TripStatus.ONGOING;
 import static dev.tripdraw.exception.trip.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
+import static dev.tripdraw.exception.trip.TripExceptionType.ONE_OR_NO_POINT;
 import static dev.tripdraw.exception.trip.TripExceptionType.TRIP_INVALID_STATUS;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -17,6 +18,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.Duration;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -78,6 +80,18 @@ public class Trip extends BaseEntity {
         if (!this.member.equals(member)) {
             throw new TripException(NOT_AUTHORIZED_TO_TRIP);
         }
+    }
+
+    public TripDuration calculateTripDuration() {
+        List<Point> points = points();
+        if (points.size() == 1 || points.isEmpty()) {
+            throw new TripException(ONE_OR_NO_POINT);
+        }
+        Point startingPoint = points.get(0);
+        Point arrivalPoint = points.get(points.size() - 1);
+
+        Duration between = Duration.between(startingPoint.recordedAt(), arrivalPoint.recordedAt());
+        return TripDuration.of(between);
     }
 
     public void changeStatus(TripStatus status) {

--- a/backend/src/main/java/dev/tripdraw/domain/trip/TripDuration.java
+++ b/backend/src/main/java/dev/tripdraw/domain/trip/TripDuration.java
@@ -1,0 +1,41 @@
+package dev.tripdraw.domain.trip;
+
+import java.time.Duration;
+
+public class TripDuration {
+
+    private static final String MINUTE = "분";
+    private static final String HOUR = "시간";
+    private static final String DAY = "일";
+    private static final String WHITE_SPACE = " ";
+
+    private final Duration duration;
+
+    private TripDuration(Duration duration) {
+        this.duration = duration;
+    }
+
+    public static TripDuration of(Duration duration) {
+        return new TripDuration(duration);
+    }
+
+    public String durationInMinutes() {
+        long minutes = duration.toMinutes();
+        return minutes + MINUTE;
+    }
+
+    public String durationInHoursAndMinutes() {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutes() - (hours * 60);
+
+        return hours + HOUR + WHITE_SPACE + minutes + MINUTE;
+    }
+
+    public String durationInDaysAndHoursAndMinutes() {
+        long days = duration.toDays();
+        long hours = duration.toHours() - (days * 24);
+        long minutes = duration.toMinutes() - (days * 1440) - (hours * 60);
+
+        return days + DAY + WHITE_SPACE + hours + HOUR + WHITE_SPACE + minutes + MINUTE;
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
+++ b/backend/src/main/java/dev/tripdraw/exception/trip/TripExceptionType.java
@@ -17,6 +17,7 @@ public enum TripExceptionType implements ExceptionType {
     TRIP_INVALID_STATUS(BAD_REQUEST, "잘못된 여행 상태입니다."),
     POINT_ALREADY_HAS_POST(CONFLICT, "이미 감상이 등록된 위치입니다."),
     TRIP_ALREADY_DELETED(CONFLICT, "이미 삭제된 여행입니다."),
+    ONE_OR_NO_POINT(BAD_REQUEST, ""),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/application/TripServiceTest.java
@@ -117,13 +117,10 @@ class TripServiceTest {
         tripService.deletePoint(loginUser, response.pointId(), trip.id());
 
         // then
-        Point deletedPoint = trip.route().points()
+        assertThat(trip.route().points()
                 .stream()
-                .filter(point -> Objects.equals(point.id(), response.pointId()))
-                .findFirst()
-                .get();
-
-        assertThat(deletedPoint.isDeleted()).isTrue();
+                .anyMatch(point -> Objects.equals(point.id(), response.pointId())))
+                .isFalse();
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/domain/trip/RouteLengthTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/RouteLengthTest.java
@@ -1,0 +1,50 @@
+package dev.tripdraw.domain.trip;
+
+import dev.tripdraw.exception.trip.TripException;
+import dev.tripdraw.exception.trip.TripExceptionType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RouteLengthTest {
+
+    @Test
+    void 경로의_길이를_계산한다() {
+        // given
+        List<Point> points = List.of(new Point(1.1, 1.1, LocalDateTime.now()), new Point(2.1, 1.1, LocalDateTime.now()), new Point(2.1, 2.1, LocalDateTime.now()));
+
+        // when
+        RouteLength length = RouteLength.from(points);
+
+        // then
+        Assertions.assertThat(length.lengthInKm()).isEqualTo("222.13km");
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateData")
+    void 경로에_위치정보가_하나이거나_없는_경우_예외를_발생시킨다(List<Point> points) {
+        // expect
+        Assertions.assertThatThrownBy(() -> RouteLength.from(points))
+                .isInstanceOf(TripException.class)
+                .hasMessage(TripExceptionType.ONE_OR_NO_POINT.message());
+    }
+
+    static Stream<List<Point>> generateData() {
+        return Stream.of(
+                new ArrayList<>(),
+                List.of(new Point(1.1, 1.1, LocalDateTime.now()))
+        );
+    }
+
+
+}

--- a/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
@@ -1,16 +1,15 @@
 package dev.tripdraw.domain.trip;
 
-import static dev.tripdraw.exception.trip.TripExceptionType.POINT_ALREADY_DELETED;
-import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_FOUND;
-import static dev.tripdraw.exception.trip.TripExceptionType.POINT_NOT_IN_TRIP;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import dev.tripdraw.exception.trip.TripException;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static dev.tripdraw.exception.trip.TripExceptionType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -117,6 +116,44 @@ class RouteTest {
 
         // then
         assertThat(route.points()).containsExactly(point2);
+    }
+
+    @Test
+    void 경로의_거리를_계산한다() {
+        // given
+        Route route = new Route();
+        route.add(new Point(1.1, 1.1, LocalDateTime.now()));
+        route.add(new Point(1.1, 2.1, LocalDateTime.now()));
+        route.add(new Point(2.1, 2.1, LocalDateTime.now()));
+
+        // when
+        RouteLength routeLength = route.calculateRouteLength();
+
+        // then
+        assertThat(routeLength.lengthInKm()).isEqualTo("222.18km");
+    }
+
+    @Test
+    void 경로에_위치정보가_존재하지_않으면_거리를_계산할_때_예외를_발생시킨다() {
+        // given
+        Route route = new Route();
+
+        // expect
+        assertThatThrownBy(route::calculateRouteLength)
+                .isInstanceOf(TripException.class)
+                .hasMessage(ONE_OR_NO_POINT.message());
+    }
+
+    @Test
+    void 경로에_위치정보가_하나만_존재하면_거리를_계산할_때_예외를_발생시킨다() {
+        // given
+        Route route = new Route();
+        route.add(new Point(1.1, 1.1, LocalDateTime.now()));
+
+        // expect
+        assertThatThrownBy(route::calculateRouteLength)
+                .isInstanceOf(TripException.class)
+                .hasMessage(ONE_OR_NO_POINT.message());
     }
 }
 

--- a/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/RouteTest.java
@@ -102,5 +102,21 @@ class RouteTest {
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_NOT_FOUND.message());
     }
+
+    @Test
+    void 삭제된_위치정보는_반환하지_않는다() {
+        // given
+        Route route = new Route();
+        Point point1 = new Point(1L, 1.1, 2.1, false, LocalDateTime.now());
+        Point point2 = new Point(2L, 3.1, 4.1, false, LocalDateTime.now());
+        route.add(point1);
+        route.add(point2);
+
+        // when
+        route.deletePointById(1L);
+
+        // then
+        assertThat(route.points()).containsExactly(point2);
+    }
 }
 

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripDurationTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripDurationTest.java
@@ -1,0 +1,41 @@
+package dev.tripdraw.domain.trip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TripDurationTest {
+
+    private final TripDuration tripDuration = TripDuration.of(Duration.ofMinutes(3248));
+
+    @Test
+    void 여행기간을_분_단위로_나타낸다() {
+        // given & when
+        String durationInMinutes = tripDuration.durationInMinutes();
+
+        // then
+        assertThat(durationInMinutes).isEqualTo("3248분");
+    }
+
+    @Test
+    void 여행기간을_시간과_분_단위로_나타낸다() {
+        // given & when
+        String durationInHoursAndMinutes = tripDuration.durationInHoursAndMinutes();
+
+        // then
+        assertThat(durationInHoursAndMinutes).isEqualTo("54시간 8분");
+    }
+
+    @Test
+    void 여행기간을_일과_시간과_분_단위로_나타낸다() {
+        // given & when
+        String durationInDaysAndHoursAndMinutes = tripDuration.durationInDaysAndHoursAndMinutes();
+        // then
+        assertThat(durationInDaysAndHoursAndMinutes).isEqualTo("2일 6시간 8분");
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/domain/trip/TripTest.java
@@ -278,4 +278,13 @@ class TripTest {
         // expect
         assertThat(trip.points()).containsExactly(point1);
     }
+
+    @Test
+    void 총_여행기간을_반환한다() {
+        // given
+
+        // when
+
+        // then
+    }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #289 

### 📁 작업 설명

여행의 총 시간을 계산합니다.

여행의 총 거리를 계산합니다.
- 하버-사인 공식이 아닌 구면 코사인 법칙을 이용해서 구했습니다.
- 일단 수식이 간단하여 쉬운 이해를 위하여 구면 코사인 법칙을 이용했습니다.
- 하버-사인 공식을 사용한 방법이 짧은 거리에서의 계산이 더 정확하고, 속도도 더 빠를 수 있으므로 추후 리팩터링 예정입니다.