### PR TITLE
[feat] 로그 유틸 생성 Sentry (#310)

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 keystore.properties
+sentry.properties

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
     id("com.google.gms.google-services")
     // FireBaseCrashlytics
     id("com.google.firebase.crashlytics")
+    // Sentry
+    id("io.sentry.android.gradle")
 }
 
 android {
@@ -54,6 +56,9 @@ android {
 
         manifestPlaceholders["NAVER_MAP_CLIENT_ID"] =
             localProperties.getProperty("NAVER_MAP_CLIENT_ID")
+
+        manifestPlaceholders["SENTRY_DSN"] =
+            localProperties.getProperty("SENTRY_DSN")
     }
 
     buildTypes {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,6 +5,8 @@ val localProperties = Properties()
 localProperties.load(project.rootProject.file("local.properties").inputStream())
 val keystoreProperties = Properties()
 keystoreProperties.load(project.rootProject.file("keystore.properties").inputStream())
+val sentryProperties = Properties()
+sentryProperties.load(project.rootProject.file("sentry.properties").inputStream())
 
 plugins {
     id("com.android.application")
@@ -59,7 +61,7 @@ android {
             localProperties.getProperty("NAVER_MAP_CLIENT_ID")
 
         manifestPlaceholders["SENTRY_DSN"] =
-            localProperties.getProperty("SENTRY_DSN")
+            sentryProperties.getProperty("SENTRY_DSN")
     }
 
     buildTypes {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 import java.util.Properties
 
 val localProperties = Properties()
@@ -118,6 +119,33 @@ android {
             }
         }
     }
+}
+
+// sentry 난독화 설정
+sentry {
+    includeProguardMapping.set(true)
+    autoUploadProguardMapping.set(true)
+    experimentalGuardsquareSupport.set(false)
+    uploadNativeSymbols.set(false)
+    autoUploadNativeSymbols.set(true)
+    includeNativeSources.set(false)
+    includeSourceContext.set(false)
+    tracingInstrumentation {
+        enabled.set(true)
+        features.set(
+            setOf(
+                InstrumentationFeature.DATABASE,
+                InstrumentationFeature.FILE_IO,
+                InstrumentationFeature.OKHTTP,
+                InstrumentationFeature.COMPOSE,
+            ),
+        )
+    }
+    autoInstallation {
+        enabled.set(true)
+        sentryVersion.set("6.28.0")
+    }
+    includeDependenciesReport.set(true)
 }
 
 dependencies {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -191,4 +191,7 @@ dependencies {
 
     // splashScreen
     implementation(libs.splashScreen)
+
+    // timber
+    implementation(libs.timber)
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,27 +32,21 @@
             android:value="${NAVER_MAP_CLIENT_ID}" />
 
         <!-- Sentry 관련 세팅 -->
-        <!-- Required: set your sentry.io project identifier (DSN) -->
         <meta-data
             android:name="io.sentry.dsn"
             android:value="${SENTRY_DSN}" />
-        <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
         <meta-data
             android:name="io.sentry.traces.user-interaction.enable"
             android:value="true" />
-        <!-- enable screenshot for crashes -->
         <meta-data
             android:name="io.sentry.attach-screenshot"
             android:value="true" />
-        <!-- enable view hierarchy for crashes -->
         <meta-data
             android:name="io.sentry.attach-view-hierarchy"
             android:value="true" />
-        <!-- enable the performance API by setting a sample-rate, adjust in production env -->
         <meta-data
             android:name="io.sentry.traces.sample-rate"
             android:value="1.0" />
-        <!-- enable profiling when starting transactions, adjust in production env -->
         <meta-data
             android:name="io.sentry.traces.profiling.sample-rate"
             android:value="1.0" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,9 +50,18 @@
         <meta-data
             android:name="io.sentry.traces.profiling.sample-rate"
             android:value="1.0" />
+        <!-- 디버그 모드 활성화 -->
         <meta-data
             android:name="io.sentry.debug"
             android:value="true" />
+        <!-- ANR 리포팅 비활성화 설정 -->
+        <meta-data
+            android:name="io.sentry.anr.enable"
+            android:value="false" />
+        <meta-data
+            android:name="io.sentry.anr.timeout-interval-millis"
+            android:value="20000" />
+
 
         <service
             android:name=".ui.home.recordingPoint.RecordingPointService"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,10 +50,6 @@
         <meta-data
             android:name="io.sentry.traces.profiling.sample-rate"
             android:value="1.0" />
-        <!-- 디버그 모드 활성화 -->
-        <meta-data
-            android:name="io.sentry.debug"
-            android:value="true" />
         <!-- ANR 리포팅 비활성화 설정 -->
         <meta-data
             android:name="io.sentry.anr.enable"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,9 @@
         <meta-data
             android:name="io.sentry.traces.profiling.sample-rate"
             android:value="1.0" />
+        <meta-data
+            android:name="io.sentry.debug"
+            android:value="true" />
 
         <service
             android:name=".ui.home.recordingPoint.RecordingPointService"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,32 @@
             android:name="com.naver.maps.map.CLIENT_ID"
             android:value="${NAVER_MAP_CLIENT_ID}" />
 
+        <!-- Sentry 관련 세팅 -->
+        <!-- Required: set your sentry.io project identifier (DSN) -->
+        <meta-data
+            android:name="io.sentry.dsn"
+            android:value="${SENTRY_DSN}" />
+        <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
+        <meta-data
+            android:name="io.sentry.traces.user-interaction.enable"
+            android:value="true" />
+        <!-- enable screenshot for crashes -->
+        <meta-data
+            android:name="io.sentry.attach-screenshot"
+            android:value="true" />
+        <!-- enable view hierarchy for crashes -->
+        <meta-data
+            android:name="io.sentry.attach-view-hierarchy"
+            android:value="true" />
+        <!-- enable the performance API by setting a sample-rate, adjust in production env -->
+        <meta-data
+            android:name="io.sentry.traces.sample-rate"
+            android:value="1.0" />
+        <!-- enable profiling when starting transactions, adjust in production env -->
+        <meta-data
+            android:name="io.sentry.traces.profiling.sample-rate"
+            android:value="1.0" />
+
         <service
             android:name=".ui.home.recordingPoint.RecordingPointService"
             android:description="@string/recording_point_service_description"

--- a/android/app/src/main/java/com/teamtripdraw/android/TripDrawApplication.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/TripDrawApplication.kt
@@ -10,6 +10,7 @@ import com.teamtripdraw.android.di.RemoteDataSourceContainer
 import com.teamtripdraw.android.di.RepositoryContainer
 import com.teamtripdraw.android.di.RetrofitContainer
 import com.teamtripdraw.android.di.ServiceContainer
+import timber.log.Timber
 
 class TripDrawApplication : Application() {
 
@@ -18,6 +19,7 @@ class TripDrawApplication : Application() {
         initContainer()
         prohibitDarkMode()
         initKakaoSdk()
+        initTimber()
     }
 
     private fun initKakaoSdk() {
@@ -37,6 +39,16 @@ class TripDrawApplication : Application() {
 
     private fun prohibitDarkMode() {
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+    }
+
+    private fun initTimber() {
+        if (!BuildConfig.IS_RELEASE) Timber.plant(getTripDrawDebugTree())
+    }
+
+    private fun getTripDrawDebugTree() = object : Timber.DebugTree() {
+        override fun createStackElementTag(element: StackTraceElement): String? {
+            return "${element.fileName}:${element.lineNumber}"
+        }
     }
 
     companion object DependencyContainer {

--- a/android/app/src/main/java/com/teamtripdraw/android/TripDrawApplication.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/TripDrawApplication.kt
@@ -10,6 +10,8 @@ import com.teamtripdraw.android.di.RemoteDataSourceContainer
 import com.teamtripdraw.android.di.RepositoryContainer
 import com.teamtripdraw.android.di.RetrofitContainer
 import com.teamtripdraw.android.di.ServiceContainer
+import com.teamtripdraw.android.support.framework.presentation.log.LogUtil
+import com.teamtripdraw.android.support.framework.presentation.log.tripDrawLogUtil.TripDrawLogUtil
 import timber.log.Timber
 
 class TripDrawApplication : Application() {
@@ -20,6 +22,7 @@ class TripDrawApplication : Application() {
         prohibitDarkMode()
         initKakaoSdk()
         initTimber()
+        initLogUtil()
     }
 
     private fun initKakaoSdk() {
@@ -51,6 +54,10 @@ class TripDrawApplication : Application() {
         }
     }
 
+    private fun initLogUtil() {
+        logUtil = TripDrawLogUtil()
+    }
+
     companion object DependencyContainer {
         lateinit var localPreferenceContainer: LocalPreferenceContainer
         lateinit var retrofitContainer: RetrofitContainer
@@ -58,5 +65,7 @@ class TripDrawApplication : Application() {
         lateinit var localDataSourceContainer: LocalDataSourceContainer
         lateinit var remoteDataSourceContainer: RemoteDataSourceContainer
         lateinit var repositoryContainer: RepositoryContainer
+
+        lateinit var logUtil: LogUtil
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.jlleitschuh) apply false
     alias(libs.plugins.fireBasePlugIn) apply false
     alias(libs.plugins.firebaseCrashlyticsPlugIn) apply false
-    alias(libs.plugins.sentry) apply false
+    alias(libs.plugins.sentryPlugin) apply false
 }
 
 allprojects {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.jlleitschuh) apply false
     alias(libs.plugins.fireBasePlugIn) apply false
     alias(libs.plugins.firebaseCrashlyticsPlugIn) apply false
+    alias(libs.plugins.sentry) apply false
 }
 
 allprojects {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -86,8 +86,11 @@ kakaoUser = "2.15.0"
 # splashScreen
 splashScreen = "1.0.0-alpha01"
 
+# sentryPlugin
+sentryPlugin = "3.12.0"
+
 # sentry
-sentry = "3.12.0"
+sentry = "6.28.0"
 
 [libraries]
 # AndroidX Libraries
@@ -169,6 +172,9 @@ kakaoUser = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoUser" }
 # splashScreen
 splashScreen = { module = "androidx.core:core-splashscreen", version.ref = "splashScreen" }
 
+# sentry
+sentry = { module = "io.sentry:sentry-android", version.ref = "sentry" }
+
 [bundles]
 domainTest = ["junitJupiter", "assertjCore"]
 androidUnitTest = ["jupiterApi", "jupiterEngine", "parameterizedTest", "junit4", "junit4VintageEngine", "assertj", "mockk", "coroutineTest", "coreTest"]
@@ -191,5 +197,5 @@ fireBasePlugIn = { id = "com.google.gms.google-services", version.ref = "fireBas
 firebaseCrashlyticsPlugIn = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugIn" }
 # use junit5 for test
 mannodermaus = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus" }
-# sentry
-sentry = { id = "io.sentry.android.gradle", version.ref = "sentry" }
+# sentryPlugin
+sentryPlugin = { id = "io.sentry.android.gradle", version.ref = "sentryPlugin" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -92,6 +92,9 @@ sentryPlugin = "3.12.0"
 # sentry
 sentry = "6.28.0"
 
+# timber
+timber = "5.0.1"
+
 [libraries]
 # AndroidX Libraries
 coreKtx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -174,6 +177,9 @@ splashScreen = { module = "androidx.core:core-splashscreen", version.ref = "spla
 
 # sentry
 sentry = { module = "io.sentry:sentry-android", version.ref = "sentry" }
+
+# timber
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 [bundles]
 domainTest = ["junitJupiter", "assertjCore"]

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -86,6 +86,9 @@ kakaoUser = "2.15.0"
 # splashScreen
 splashScreen = "1.0.0-alpha01"
 
+# sentry
+sentry = "3.12.0"
+
 [libraries]
 # AndroidX Libraries
 coreKtx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -186,6 +189,7 @@ jlleitschuh = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "jlleitschuh
 fireBasePlugIn = { id = "com.google.gms.google-services", version.ref = "fireBasePlugIn" }
 # firebaseCrashlytics
 firebaseCrashlyticsPlugIn = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugIn" }
-
 # use junit5 for test
 mannodermaus = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus" }
+# sentry
+sentry = { id = "io.sentry.android.gradle", version.ref = "sentry" }

--- a/android/support/build.gradle.kts
+++ b/android/support/build.gradle.kts
@@ -18,10 +18,14 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
+            buildConfigField("Boolean", "IS_RELEASE", "true")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
+        }
+        getByName("debug") {
+            buildConfigField("Boolean", "IS_RELEASE", "false")
         }
     }
     compileOptions {

--- a/android/support/build.gradle.kts
+++ b/android/support/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    // Sentry
+    id("io.sentry.android.gradle")
 }
 
 android {

--- a/android/support/build.gradle.kts
+++ b/android/support/build.gradle.kts
@@ -67,4 +67,9 @@ dependencies {
 
     // timber
     implementation(libs.timber)
+
+    // FireBase
+    releaseImplementation(platform(libs.fireBaseBom))
+    // FirebaseCrashlytics
+    releaseImplementation(libs.fireBaseCrashlyticsKtx)
 }

--- a/android/support/build.gradle.kts
+++ b/android/support/build.gradle.kts
@@ -64,4 +64,7 @@ dependencies {
 
     // sentry
     implementation(libs.sentry)
+
+    // timber
+    implementation(libs.timber)
 }

--- a/android/support/build.gradle.kts
+++ b/android/support/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
-    // Sentry
-    id("io.sentry.android.gradle")
 }
 
 android {
@@ -63,4 +61,7 @@ dependencies {
 
     // kakaoLogin
     implementation(libs.kakaoUser)
+
+    // sentry
+    implementation(libs.sentry)
 }

--- a/android/support/src/debug/java/CrashlyticsHandlerImpl.kt
+++ b/android/support/src/debug/java/CrashlyticsHandlerImpl.kt
@@ -1,0 +1,7 @@
+import com.teamtripdraw.android.support.framework.presentation.log.tripDrawLogUtil.CrashlyticsHandler
+
+class CrashlyticsHandlerImpl : CrashlyticsHandler {
+    override fun recordException(throwable: Throwable, keyName: String, keyValue: String) {
+        // no_op
+    }
+}

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
@@ -1,6 +1,6 @@
 package com.teamtripdraw.android.support.framework.presentation.log
 
 interface LogUtil {
+    fun general(throwable: Throwable?, message: String? = null)
     fun httpClient()
-    fun general(className: String, functionName: String, message: String? = null)
 }

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
@@ -1,6 +1,15 @@
 package com.teamtripdraw.android.support.framework.presentation.log
 
+import okhttp3.ResponseBody
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
 interface LogUtil {
     fun general(throwable: Throwable?, message: String? = null)
-    fun httpClient()
+    interface HttpClient {
+        fun failure(code: Int, errorBody: ResponseBody?)
+        fun network(error: UnknownHostException)
+        fun timeOut(error: SocketTimeoutException)
+        fun unknown(error: Throwable)
+    }
 }

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
@@ -5,7 +5,12 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 interface LogUtil {
-    fun general(throwable: Throwable?, message: String? = null)
+
+    val general: General
+
+    interface General {
+        fun log(throwable: Throwable?, message: String? = null)
+    }
 
     val httpClient: HttpClient
 

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
@@ -6,6 +6,9 @@ import java.net.UnknownHostException
 
 interface LogUtil {
     fun general(throwable: Throwable?, message: String? = null)
+
+    val httpClient: HttpClient
+
     interface HttpClient {
         fun failure(code: Int, errorBody: ResponseBody?)
         fun network(error: UnknownHostException)

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/LogUtil.kt
@@ -1,0 +1,6 @@
+package com.teamtripdraw.android.support.framework.presentation.log
+
+interface LogUtil {
+    fun httpClient()
+    fun general(className: String, functionName: String, message: String? = null)
+}

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/TripDrawLogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/TripDrawLogUtil.kt
@@ -1,0 +1,34 @@
+package com.teamtripdraw.android.support.framework.presentation.log
+
+import android.util.Log
+import com.teamtripdraw.android.support.BuildConfig.IS_RELEASE
+
+object TripDrawLogUtil : LogUtil {
+
+    private const val DEBUG_GENERAL_ERROR_LOG = "DEBUG_GENERAL_ERROR_LOG_%s"
+    private const val RELEASE_GENERAL_ERROR_LOG = "RELEASE_GENERAL_ERROR_LOG_%s"
+    private const val DEBUG_HTTP_CLIENT_ERROR_LOG = "DEBUG_HTTP_CLIENT_ERROR_LOG_%s"
+    private const val RELEASE_HTTP_CLIENT_ERROR_LOG = "DEBUG_HTTP_CLIENT_ERROR_LOG_%s"
+    private const val CLASS_NAME = "CLASS_NAME"
+    private const val MESSAGE = "MESSAGE"
+
+    override fun httpClient() {
+        // todo Sentry 연결후 관련 로그 작성
+    }
+
+    override fun general(className: String, functionName: String, message: String?) {
+        when (IS_RELEASE) {
+            true -> generalReleaseErrorLog(className, functionName, message)
+            false -> generalDebugErrorLog(className, functionName, message)
+        }
+    }
+
+    private fun generalReleaseErrorLog(className: String, functionName: String, message: String?) {
+        // todo Sentry 연결후 관련 로그 작성
+    }
+
+    private fun generalDebugErrorLog(className: String, functionName: String, message: String?) {
+        // todo Sentry 연결후 관련 로그 작성
+        Log.e(DEBUG_GENERAL_ERROR_LOG, functionName + (message ?: ""))
+    }
+}

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/TripDrawLogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/TripDrawLogUtil.kt
@@ -1,34 +1,60 @@
 package com.teamtripdraw.android.support.framework.presentation.log
 
-import android.util.Log
 import com.teamtripdraw.android.support.BuildConfig.IS_RELEASE
+import io.sentry.Sentry
+import timber.log.Timber
 
 object TripDrawLogUtil : LogUtil {
 
-    private const val DEBUG_GENERAL_ERROR_LOG = "DEBUG_GENERAL_ERROR_LOG_%s"
-    private const val RELEASE_GENERAL_ERROR_LOG = "RELEASE_GENERAL_ERROR_LOG_%s"
-    private const val DEBUG_HTTP_CLIENT_ERROR_LOG = "DEBUG_HTTP_CLIENT_ERROR_LOG_%s"
-    private const val RELEASE_HTTP_CLIENT_ERROR_LOG = "DEBUG_HTTP_CLIENT_ERROR_LOG_%s"
-    private const val CLASS_NAME = "CLASS_NAME"
-    private const val MESSAGE = "MESSAGE"
+    private const val DEBUG_GENERAL_ERROR_LOG_FORMAT = "message : %s"
+    private const val DEBUG_HTTP_CLIENT_ERROR_LOG = "DEBUG_HTTP_CLIENT_ERROR_LOG"
+    private const val RELEASE_HTTP_CLIENT_ERROR_LOG = "DEBUG_HTTP_CLIENT_ERROR_LOG"
+    private const val SENTRY_MESSAGE_KEY = "ERROR_MESSAGE"
+    private const val NO_MESSAGE_NOTICE = "입력된 메시지가 없습니다."
 
-    override fun httpClient() {
-        // todo Sentry 연결후 관련 로그 작성
-    }
 
-    override fun general(className: String, functionName: String, message: String?) {
+//    override fun httpClient() {
+//        when (IS_RELEASE) {
+//            true -> httpClientReleaseErrorLog()
+//            false -> httpClientDebugErrorLog()
+//        }
+//    }
+//
+//    private fun httpClientReleaseErrorLog() {
+//        // todo Sentry 연결후 관련 로그 작성
+//    }
+//
+//    private fun httpClientDebugErrorLog() {
+//        Log.e(DEBUG_GENERAL_ERROR_LOG_FORMAT, functionName + (message ?: ""))
+//    }
+
+    override fun general(throwable: Throwable?, message: String?) {
         when (IS_RELEASE) {
-            true -> generalReleaseErrorLog(className, functionName, message)
-            false -> generalDebugErrorLog(className, functionName, message)
+            true -> generalReleaseErrorLog(throwable, message)
+            false -> generalDebugErrorLog(throwable, message)
         }
     }
 
-    private fun generalReleaseErrorLog(className: String, functionName: String, message: String?) {
-        // todo Sentry 연결후 관련 로그 작성
+    private fun generalReleaseErrorLog(throwable: Throwable?, message: String?) {
+        when (throwable == null) {
+            true -> {
+                Sentry.captureMessage(message ?: NO_MESSAGE_NOTICE)
+            }
+            false -> {
+                Sentry.captureException(throwable) { scope ->
+                    scope.setContexts(SENTRY_MESSAGE_KEY, message ?: NO_MESSAGE_NOTICE)
+                }
+            }
+        }
     }
 
-    private fun generalDebugErrorLog(className: String, functionName: String, message: String?) {
-        // todo Sentry 연결후 관련 로그 작성
-        Log.e(DEBUG_GENERAL_ERROR_LOG, functionName + (message ?: ""))
+    private fun generalDebugErrorLog(throwable: Throwable?, message: String?) {
+        when (throwable == null) {
+            true -> Timber.e(DEBUG_GENERAL_ERROR_LOG_FORMAT.format(message ?: NO_MESSAGE_NOTICE))
+            false -> Timber.e(
+                throwable,
+                DEBUG_GENERAL_ERROR_LOG_FORMAT.format(message ?: NO_MESSAGE_NOTICE),
+            )
+        }
     }
 }

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/CrashlyticsHandler.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/CrashlyticsHandler.kt
@@ -1,0 +1,5 @@
+package com.teamtripdraw.android.support.framework.presentation.log.tripDrawLogUtil
+
+interface CrashlyticsHandler {
+    fun recordException(throwable: Throwable, keyName: String, keyValue: String)
+}

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/TripDrawLogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/TripDrawLogUtil.kt
@@ -10,33 +10,40 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
 class TripDrawLogUtil() : LogUtil {
-    override fun general(throwable: Throwable?, message: String?) {
-        when (IS_RELEASE) {
-            true -> generalReleaseErrorLog(throwable, message)
-            false -> generalDebugErrorLog(throwable, message)
-        }
-    }
+    override val general: LogUtil.General = object : LogUtil.General {
 
-    private fun generalReleaseErrorLog(throwable: Throwable?, message: String?) {
-        when (throwable == null) {
-            true -> {
-                Sentry.captureMessage(message ?: NO_MESSAGE_NOTICE)
+        override fun log(throwable: Throwable?, message: String?) {
+            when (IS_RELEASE) {
+                true -> generalReleaseErrorLog(throwable, message)
+                false -> generalDebugErrorLog(throwable, message)
             }
-            false -> {
-                Sentry.captureException(throwable) { scope ->
-                    scope.setContexts(SENTRY_MESSAGE_KEY, message ?: NO_MESSAGE_NOTICE)
+        }
+
+        private fun generalReleaseErrorLog(throwable: Throwable?, message: String?) {
+            when (throwable == null) {
+                true -> {
+                    Sentry.captureMessage(message ?: NO_MESSAGE_NOTICE)
+                }
+                false -> {
+                    Sentry.captureException(throwable) { scope ->
+                        scope.setContexts(SENTRY_MESSAGE_KEY, message ?: NO_MESSAGE_NOTICE)
+                    }
                 }
             }
         }
-    }
 
-    private fun generalDebugErrorLog(throwable: Throwable?, message: String?) {
-        when (throwable == null) {
-            true -> Timber.e(DEBUG_GENERAL_ERROR_LOG_FORMAT.format(message ?: NO_MESSAGE_NOTICE))
-            false -> Timber.e(
-                throwable,
-                DEBUG_GENERAL_ERROR_LOG_FORMAT.format(message ?: NO_MESSAGE_NOTICE),
-            )
+        private fun generalDebugErrorLog(throwable: Throwable?, message: String?) {
+            when (throwable == null) {
+                true -> Timber.e(
+                    DEBUG_GENERAL_ERROR_LOG_FORMAT.format(
+                        message ?: NO_MESSAGE_NOTICE,
+                    ),
+                )
+                false -> Timber.e(
+                    throwable,
+                    DEBUG_GENERAL_ERROR_LOG_FORMAT.format(message ?: NO_MESSAGE_NOTICE),
+                )
+            }
         }
     }
 

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/TripDrawLogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/TripDrawLogUtil.kt
@@ -40,7 +40,8 @@ class TripDrawLogUtil() : LogUtil {
         }
     }
 
-    inner class HttpClient : LogUtil.HttpClient {
+    override val httpClient: LogUtil.HttpClient = object : LogUtil.HttpClient {
+
         private val crashlyticsHandler: CrashlyticsHandler = CrashlyticsHandlerImpl()
 
         override fun failure(code: Int, errorBody: ResponseBody?) {

--- a/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/TripDrawLogUtil.kt
+++ b/android/support/src/main/java/com/teamtripdraw/android/support/framework/presentation/log/tripDrawLogUtil/TripDrawLogUtil.kt
@@ -1,6 +1,8 @@
-package com.teamtripdraw.android.support.framework.presentation.log
+package com.teamtripdraw.android.support.framework.presentation.log.tripDrawLogUtil
 
+import CrashlyticsHandlerImpl
 import com.teamtripdraw.android.support.BuildConfig.IS_RELEASE
+import com.teamtripdraw.android.support.framework.presentation.log.LogUtil
 import io.sentry.Sentry
 import okhttp3.ResponseBody
 import timber.log.Timber
@@ -39,6 +41,8 @@ class TripDrawLogUtil() : LogUtil {
     }
 
     inner class HttpClient : LogUtil.HttpClient {
+        private val crashlyticsHandler: CrashlyticsHandler = CrashlyticsHandlerImpl()
+
         override fun failure(code: Int, errorBody: ResponseBody?) {
             when (IS_RELEASE) {
                 true -> failureReleaseLog(code, errorBody)
@@ -69,7 +73,11 @@ class TripDrawLogUtil() : LogUtil {
         }
 
         private fun networkReleaseLog(error: UnknownHostException) {
-            // 크래시리틱스
+            crashlyticsHandler.recordException(
+                error,
+                CRASHLYTICS_HTTP_ERROR_KEY_NAME,
+                RESPONSE_STATE_NETWORK,
+            )
         }
 
         private fun networkDebugLog(error: UnknownHostException) {
@@ -116,6 +124,7 @@ class TripDrawLogUtil() : LogUtil {
         private const val SENTRY_MESSAGE_KEY = "ERROR_MESSAGE"
         private const val NO_MESSAGE_NOTICE = "입력된 메시지가 없습니다."
         private const val SENTRY_HTTP_ERROR_TAG_KEY = "HTTP_ERROR"
+        private const val CRASHLYTICS_HTTP_ERROR_KEY_NAME = SENTRY_HTTP_ERROR_TAG_KEY
         private const val DEBUG_RESPONSE_STATE_FAILURE =
             "RESPONSE_STATE_FAILURE code: %d errorBody: %s"
         private const val SENTRY_RESPONSE_STATE_FAILURE_MESSAGE = "HTTP_FAILURE"

--- a/android/support/src/release/java/CrashlyticsHandlerImpl.kt
+++ b/android/support/src/release/java/CrashlyticsHandlerImpl.kt
@@ -1,0 +1,12 @@
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import com.teamtripdraw.android.support.framework.presentation.log.tripDrawLogUtil.CrashlyticsHandler
+
+class CrashlyticsHandlerImpl : CrashlyticsHandler {
+    override fun recordException(throwable: Throwable, keyName: String, keyValue: String) {
+        Firebase.crashlytics.run {
+            setCustomKey(keyName, keyValue)
+            recordException(throwable)
+        }
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈

- closed #310 

### 📁 작업 설명

- 방학동안 원격로깅 툴 연결하고 로그유틸 만들어봤습니다.
이에 대한 일대기는 블로그와 이슈에 열심히 남겨두었으니 두개 참고하셔서 학습하시고 사용하시길 바랍니다!!!!
[멧돼지의 파워블로그](https://mccoy-devloper.tistory.com/131)

시간나실때 본인 부분 Log찍어야 했던 것 다 Logutil의 genral 로 변경해주시면됩니다