### PR TITLE
[feat] 여행 이미지에 대한 기본 값 지정하는 기능 추가 (#341)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/file/application/FilePath.java
+++ b/backend/src/main/java/dev/tripdraw/file/application/FilePath.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.file.application;
 
-import static dev.tripdraw.file.domain.FileType.POST_IMAGE;
+import static dev.tripdraw.file.domain.FileType.IMAGE;
 
 import dev.tripdraw.file.domain.FileType;
 import java.util.Map;
@@ -20,7 +20,7 @@ public class FilePath {
 
     public String getPath(FileType fileType) {
         Map<FileType, String> typeAndPath = Map.of(
-                POST_IMAGE, postImagePath
+                IMAGE, postImagePath
         );
 
         return typeAndPath.get(fileType);
@@ -28,7 +28,7 @@ public class FilePath {
 
     public String getPathWithBase(FileType fileType) {
         Map<FileType, String> typeAndPath = Map.of(
-                POST_IMAGE, base + postImagePath
+                IMAGE, base + postImagePath
         );
 
         return typeAndPath.get(fileType);

--- a/backend/src/main/java/dev/tripdraw/file/application/FileUploader.java
+++ b/backend/src/main/java/dev/tripdraw/file/application/FileUploader.java
@@ -19,6 +19,9 @@ public class FileUploader {
     private final FileUrlMaker fileUrlMaker;
 
     public String upload(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
         FileType type = FileType.from(file.getContentType());
         UUID id = UUID.randomUUID();
         String filePathWithBase = filePath.getPathWithBase(type) + id + type.extension();

--- a/backend/src/main/java/dev/tripdraw/file/application/FileUploader.java
+++ b/backend/src/main/java/dev/tripdraw/file/application/FileUploader.java
@@ -18,16 +18,13 @@ public class FileUploader {
     private final FilePath filePath;
     private final FileUrlMaker fileUrlMaker;
 
-    public String upload(MultipartFile file, FileType fileType) {
-        if (file == null || file.isEmpty()) {
-            return null;
-        }
-
+    public String upload(MultipartFile file) {
+        FileType type = FileType.from(file.getContentType());
         UUID id = UUID.randomUUID();
-        String filePathWithBase = filePath.getPathWithBase(fileType) + id + fileType.extension();
+        String filePathWithBase = filePath.getPathWithBase(type) + id + type.extension();
         fileUpload(file, filePathWithBase);
 
-        return fileUrlMaker.make(filePath.getPath(fileType) + id + fileType.extension());
+        return fileUrlMaker.make(filePath.getPath(type) + id + type.extension());
     }
 
     private void fileUpload(MultipartFile file, String filePathWithBase) {

--- a/backend/src/main/java/dev/tripdraw/file/domain/FileType.java
+++ b/backend/src/main/java/dev/tripdraw/file/domain/FileType.java
@@ -12,7 +12,7 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @Getter
 public enum FileType {
-    POST_IMAGE(IMAGE_JPEG_VALUE, ".jpg"),
+    IMAGE(IMAGE_JPEG_VALUE, ".jpg"),
     ;
 
     private final String contentType;

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -1,12 +1,10 @@
 package dev.tripdraw.post.application;
 
-import static dev.tripdraw.file.domain.FileType.POST_IMAGE;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
 import dev.tripdraw.common.auth.LoginUser;
 import dev.tripdraw.file.application.FileUploader;
-import dev.tripdraw.file.domain.FileType;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.post.domain.Post;
@@ -116,7 +114,7 @@ public class PostService {
         if (file == null) {
             return;
         }
-        String imageUrl = fileUploader.upload(file, POST_IMAGE);
+        String imageUrl = fileUploader.upload(file);
         post.changePostImageUrl(imageUrl);
     }
 
@@ -130,8 +128,7 @@ public class PostService {
         if (file == null) {
             return post;
         }
-        FileType type = FileType.from(file.getContentType());
-        String fileUrl = fileUploader.upload(file, type);
+        String fileUrl = fileUploader.upload(file);
 
         post.changePostImageUrl(fileUrl);
         return post;

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.post.application;
 
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
@@ -20,7 +21,6 @@ import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
-import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -45,18 +45,25 @@ public class PostService {
             MultipartFile file
     ) {
         Member member = memberRepository.getById(loginUser.memberId());
-        Trip trip = findValidatedTripById(postAndPointCreateRequest.tripId(), member);
-
-        Point point = postAndPointCreateRequest.toPoint();
-        point.setTrip(trip);
-        pointRepository.save(point);
+        Trip trip = tripRepository.getById(postAndPointCreateRequest.tripId());
+        trip.validateAuthorization(member);
+        Point point = pointRepository.save(postAndPointCreateRequest.toPoint(trip));
 
         Post post = postAndPointCreateRequest.toPost(member, point);
-        Post savedPost = postRepository.save(registerFileToPost(file, post));
+        uploadImage(file, post, trip);
+        Post savedPost = postRepository.save(post);
 
         applicationEventPublisher.publishEvent(new PostCreateEvent(post.id(), trip.id()));
-
         return PostCreateResponse.from(savedPost);
+    }
+
+    private void uploadImage(MultipartFile file, Post post, Trip trip) {
+        String filename = fileUploader.upload(file);
+        if (filename == null) {
+            return;
+        }
+        post.changePostImageUrl(filename);
+        trip.changeImageUrl(filename);
     }
 
     public PostCreateResponse addAtExistingLocation(
@@ -65,17 +72,19 @@ public class PostService {
             MultipartFile file
     ) {
         Member member = memberRepository.getById(loginUser.memberId());
-        Trip trip = findValidatedTripById(postRequest.tripId(), member);
+        Trip trip = tripRepository.getById(postRequest.tripId());
+        trip.validateAuthorization(member);
         Point point = pointRepository.getById(postRequest.pointId());
 
         Post post = postRequest.toPost(member, point);
-        Post savedPost = postRepository.save(registerFileToPost(file, post));
+        uploadImage(file, post, trip);
+        Post savedPost = postRepository.save(post);
 
         applicationEventPublisher.publishEvent(new PostCreateEvent(post.id(), trip.id()));
-
         return PostCreateResponse.from(savedPost);
     }
 
+    @Transactional(readOnly = true)
     public PostResponse read(LoginUser loginUser, Long postId) {
         Post post = postRepository.getById(postId);
         Member member = memberRepository.getById(loginUser.memberId());
@@ -83,12 +92,14 @@ public class PostService {
         return PostResponse.from(post);
     }
 
+    @Transactional(readOnly = true)
     public PostsResponse readAllByTripId(LoginUser loginUser, Long tripId) {
         Member member = memberRepository.getById(loginUser.memberId());
-        findValidatedTripById(tripId, member);
+        Trip trip = tripRepository.getById(tripId);
+        trip.validateAuthorization(member);
 
         return postRepository.findAllByTripId(tripId).stream()
-                .sorted(Comparator.comparing(Post::pointRecordedAt).reversed())
+                .sorted(comparing(Post::id).reversed())
                 .collect(collectingAndThen(toList(), PostsResponse::from));
     }
 
@@ -96,42 +107,19 @@ public class PostService {
         Post post = postRepository.getById(postId);
         Member member = memberRepository.getById(loginUser.memberId());
         post.validateAuthorization(member);
+        Trip trip = tripRepository.getById(post.tripId());
+        trip.validateAuthorization(member);
 
         post.changeTitle(postUpdateRequest.title());
         post.changeWriting(postUpdateRequest.writing());
-        updateFileOfPost(file, post);
+        uploadImage(file, post, trip);
     }
 
     public void delete(LoginUser loginUser, Long postId) {
         Post post = postRepository.getById(postId);
         Member member = memberRepository.getById(loginUser.memberId());
         post.validateAuthorization(member);
-
         postRepository.deleteById(postId);
-    }
-
-    private void updateFileOfPost(MultipartFile file, Post post) {
-        if (file == null) {
-            return;
-        }
-        String imageUrl = fileUploader.upload(file);
-        post.changePostImageUrl(imageUrl);
-    }
-
-    private Trip findValidatedTripById(Long tripId, Member member) {
-        Trip trip = tripRepository.getById(tripId);
-        trip.validateAuthorization(member);
-        return trip;
-    }
-
-    private Post registerFileToPost(MultipartFile file, Post post) {
-        if (file == null) {
-            return post;
-        }
-        String fileUrl = fileUploader.upload(file);
-
-        post.changePostImageUrl(fileUrl);
-        return post;
     }
 }
 

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -99,7 +99,7 @@ public class PostService {
         trip.validateAuthorization(member);
 
         return postRepository.findAllByTripId(tripId).stream()
-                .sorted(comparing(Post::id).reversed())
+                .sorted(comparing(Post::pointRecordedAt).reversed())
                 .collect(collectingAndThen(toList(), PostsResponse::from));
     }
 

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostAndPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostAndPointCreateRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.trip.domain.Point;
+import dev.tripdraw.trip.domain.Trip;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -46,6 +47,10 @@ public record PostAndPointCreateRequest(
 
     public Point toPoint() {
         return new Point(latitude, longitude, recordedAt);
+    }
+
+    public Point toPoint(Trip trip) {
+        return new Point(latitude, longitude, recordedAt, trip);
     }
 
     public Post toPost(Member member, Point point) {

--- a/backend/src/main/java/dev/tripdraw/trip/domain/Point.java
+++ b/backend/src/main/java/dev/tripdraw/trip/domain/Point.java
@@ -48,6 +48,10 @@ public class Point extends BaseEntity {
         this(null, latitude, longitude, false, recordedAt, null);
     }
 
+    public Point(Double latitude, Double longitude, LocalDateTime recordedAt, Trip trip) {
+        this(null, latitude, longitude, false, recordedAt, trip);
+    }
+
     public Point(Double latitude, Double longitude, boolean hasPost, LocalDateTime recordedAt) {
         this(null, latitude, longitude, hasPost, recordedAt, null);
     }

--- a/backend/src/test/java/dev/tripdraw/file/application/FileUploaderTest.java
+++ b/backend/src/test/java/dev/tripdraw/file/application/FileUploaderTest.java
@@ -68,7 +68,7 @@ class FileUploaderTest {
     }
 
     @Test
-    void 파일_저장에_실패할시_예외륿_발생시킨다() throws IOException {
+    void 파일_저장에_실패할시_예외를_발생시킨다() throws IOException {
         // given
         MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
         when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());

--- a/backend/src/test/java/dev/tripdraw/file/application/FileUploaderTest.java
+++ b/backend/src/test/java/dev/tripdraw/file/application/FileUploaderTest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.file.application;
 
+import static dev.tripdraw.file.domain.FileType.IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import dev.tripdraw.file.domain.FileType;
 import dev.tripdraw.file.exception.FileIOException;
 import java.io.File;
 import java.io.IOException;
@@ -44,10 +44,11 @@ class FileUploaderTest {
         String baseUrl = "https://example.com/files/";
         String expectedFileUrl = baseUrl + randomUUID + ".jpg";
         MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
+        when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());
         when(fileUrlMaker.make(any())).thenReturn(expectedFileUrl);
 
         // when
-        String url = fileUploader.upload(multipartFile, FileType.POST_IMAGE);
+        String url = fileUploader.upload(multipartFile);
 
         // then
         assertThat(url).isEqualTo(expectedFileUrl);
@@ -57,9 +58,10 @@ class FileUploaderTest {
     void 파일을_업로드_한다() throws IOException {
         // given
         MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
+        when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());
 
         // when
-        fileUploader.upload(multipartFile, FileType.POST_IMAGE);
+        fileUploader.upload(multipartFile);
 
         // then
         verify(multipartFile, times(1)).transferTo(any(File.class));
@@ -69,10 +71,11 @@ class FileUploaderTest {
     void 파일_저장에_실패할시_예외륿_발생시킨다() throws IOException {
         // given
         MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
+        when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());
         doThrow(new IOException()).when(multipartFile).transferTo(any(File.class));
 
         // expect
-        assertThatThrownBy(() -> fileUploader.upload(multipartFile, FileType.POST_IMAGE))
+        assertThatThrownBy(() -> fileUploader.upload(multipartFile))
                 .isInstanceOf(FileIOException.class);
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #341 

### 📁 작업 설명

- 여행 이미지에 대한 기본 값을 지정하는 기능을 추가했습니다.
- 이미지를 저장하는 경우 제일 마지막으로 저장된 이미지를 여행의 기본 이미지로 설정하였습니다.
- PostService의 읽기 전용 메서드에 Transactional readOnly를 추가하였습니다.
- 파일 타입을 FileUpload 내부에서 가져오도록 했습니다.
