### PR TITLE
[fix] dto의 image null인 경우 빈 문자열을 반환하도록 수정 (#343)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/post/dto/PostResponse.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostResponse.java
@@ -3,6 +3,7 @@ package dev.tripdraw.post.dto;
 import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.trip.dto.PointResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 
 public record PostResponse(
         @Schema(description = "감상의 Id", example = "1")
@@ -30,6 +31,8 @@ public record PostResponse(
         String routeImageUrl
 ) {
 
+    private static final String EMPTY_IMAGE_URL = "";
+
     public static PostResponse from(Post post) {
         return new PostResponse(
                 post.id(),
@@ -38,8 +41,8 @@ public record PostResponse(
                 post.address(),
                 post.writing(),
                 PointResponse.from(post.point()),
-                post.postImageUrl(),
-                post.routeImageUrl()
+                Objects.requireNonNullElse(post.postImageUrl(), EMPTY_IMAGE_URL),
+                Objects.requireNonNullElse(post.routeImageUrl(), EMPTY_IMAGE_URL)
         );
     }
 }

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripResponse.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripResponse.java
@@ -4,6 +4,7 @@ import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Objects;
 
 public record TripResponse(
         @Schema(description = "여행 Id", example = "1")
@@ -25,14 +26,16 @@ public record TripResponse(
         String routeImageUrl
 ) {
 
+    private static final String EMPTY_IMAGE_URL = "";
+
     public static TripResponse from(Trip trip) {
         return new TripResponse(
                 trip.id(),
                 trip.nameValue(),
                 generateRoute(trip),
                 trip.status(),
-                trip.imageUrl(),
-                trip.routeImageUrl()
+                Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL),
+                Objects.requireNonNullElse(trip.routeImageUrl(), EMPTY_IMAGE_URL)
         );
     }
 

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchResponse.java
@@ -25,7 +25,7 @@ public record TripSearchResponse(
                 trip.id(),
                 trip.nameValue(),
                 Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL),
-                Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL)
+                Objects.requireNonNullElse(trip.routeImageUrl(), EMPTY_IMAGE_URL)
         );
     }
 }

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -380,7 +380,8 @@ class PostControllerTest extends ControllerTest {
             softly.assertThat(getResponse.title()).isEqualTo("우도의 바닷가");
             softly.assertThat(getResponse.pointResponse().pointId()).isNotNull();
             softly.assertThat(getResponse.pointResponse().latitude()).isEqualTo(1.1);
-            softly.assertThat(getResponse.postImageUrl()).isNull();
+            softly.assertThat(getResponse.postImageUrl()).isEmpty();
+            softly.assertThat(getResponse.routeImageUrl()).isEmpty();
         });
     }
 


### PR DESCRIPTION
### 📌 관련 이슈

- closed #343 

### 📁 작업 설명

- 이미지가 null인 경우 빈 문자열을 반환하도록 수정했습니다.
- routeImageUrl에 imageUrl을 반환하는 부분을 수정했스빈다.