### PR TITLE
[refactor] OAuth API 호출에 해당하는 부분을 트랜잭션에서 제외 (#349)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/auth/application/AuthFacadeService.java
+++ b/backend/src/main/java/dev/tripdraw/auth/application/AuthFacadeService.java
@@ -1,0 +1,31 @@
+package dev.tripdraw.auth.application;
+
+import dev.tripdraw.auth.dto.OauthInfo;
+import dev.tripdraw.auth.dto.OauthRequest;
+import dev.tripdraw.auth.dto.OauthResponse;
+import dev.tripdraw.auth.dto.RegisterRequest;
+import dev.tripdraw.auth.dto.TokenRefreshRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthFacadeService {
+
+    private final OAuthService oAuthService;
+    private final AuthService authService;
+
+    public OauthResponse login(OauthRequest oauthRequest) {
+        OauthInfo oauthInfo = oAuthService.request(oauthRequest.oauthType(), oauthRequest.oauthToken());
+        return authService.login(oauthInfo);
+    }
+
+    public OauthResponse register(RegisterRequest registerRequest) {
+        OauthInfo oauthInfo = oAuthService.request(registerRequest.oauthType(), registerRequest.oauthToken());
+        return authService.register(oauthInfo, registerRequest.nickname());
+    }
+
+    public OauthResponse refresh(TokenRefreshRequest tokenRefreshRequest) {
+        return authService.refresh(tokenRefreshRequest.refreshToken());
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/auth/application/AuthFacadeService.java
+++ b/backend/src/main/java/dev/tripdraw/auth/application/AuthFacadeService.java
@@ -14,18 +14,23 @@ public class AuthFacadeService {
 
     private final OAuthService oAuthService;
     private final AuthService authService;
+    private final TokenGenerateService tokenGenerateService;
 
     public OauthResponse login(OauthRequest oauthRequest) {
         OauthInfo oauthInfo = oAuthService.request(oauthRequest.oauthType(), oauthRequest.oauthToken());
-        return authService.login(oauthInfo);
+        return authService.login(oauthInfo)
+                .map(member -> tokenGenerateService.generate(member.id()))
+                .orElseGet(tokenGenerateService::generateEmptyToken);
     }
 
     public OauthResponse register(RegisterRequest registerRequest) {
         OauthInfo oauthInfo = oAuthService.request(registerRequest.oauthType(), registerRequest.oauthToken());
-        return authService.register(oauthInfo, registerRequest.nickname());
+        return authService.register(oauthInfo, registerRequest.nickname())
+                .map(member -> tokenGenerateService.generate(member.id()))
+                .orElseGet(tokenGenerateService::generateEmptyToken);
     }
 
     public OauthResponse refresh(TokenRefreshRequest tokenRefreshRequest) {
-        return authService.refresh(tokenRefreshRequest.refreshToken());
+        return tokenGenerateService.refresh(tokenRefreshRequest.refreshToken());
     }
 }

--- a/backend/src/main/java/dev/tripdraw/auth/application/AuthService.java
+++ b/backend/src/main/java/dev/tripdraw/auth/application/AuthService.java
@@ -1,17 +1,13 @@
 package dev.tripdraw.auth.application;
 
-import static dev.tripdraw.auth.exception.AuthExceptionType.INVALID_TOKEN;
 import static dev.tripdraw.member.exception.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
 
-import dev.tripdraw.auth.domain.RefreshToken;
-import dev.tripdraw.auth.domain.RefreshTokenRepository;
 import dev.tripdraw.auth.dto.OauthInfo;
-import dev.tripdraw.auth.dto.OauthResponse;
-import dev.tripdraw.auth.exception.AuthException;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.member.exception.MemberException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,31 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private static final OauthResponse EMPTY_TOKEN_RESPONSE = new OauthResponse("", "");
-
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final MemberRepository memberRepository;
 
-    public OauthResponse login(OauthInfo oauthInfo) {
+    public Optional<Member> login(OauthInfo oauthInfo) {
         return memberRepository.findByOauthIdAndOauthType(oauthInfo.oauthId(), oauthInfo.oauthType())
-                .map(member -> generateOAuthResponse(member.id()))
-                .orElseGet(() -> {
+                .or(() -> {
                     memberRepository.save(Member.of(oauthInfo.oauthId(), oauthInfo.oauthType()));
-                    return EMPTY_TOKEN_RESPONSE;
+                    return Optional.empty();
                 });
     }
 
-    private OauthResponse generateOAuthResponse(Long memberId) {
-        String accessToken = jwtTokenProvider.generateAccessToken(memberId.toString());
-        String refreshToken = jwtTokenProvider.generateRefreshToken();
-
-        refreshTokenRepository.deleteByMemberId(memberId);
-        refreshTokenRepository.save(new RefreshToken(memberId, refreshToken));
-        return new OauthResponse(accessToken, refreshToken);
-    }
-
-    public OauthResponse register(OauthInfo oauthInfo, String nickname) {
+    public Optional<Member> register(OauthInfo oauthInfo, String nickname) {
         if (memberRepository.existsByNickname(nickname)) {
             throw new MemberException(DUPLICATE_NICKNAME);
         }
@@ -53,13 +35,6 @@ public class AuthService {
         Member member = memberRepository.findByOauthIdAndOauthType(oauthInfo.oauthId(), oauthInfo.oauthType())
                 .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
         member.changeNickname(nickname);
-        return generateOAuthResponse(member.id());
-    }
-
-    public OauthResponse refresh(String token) {
-        jwtTokenProvider.validateRefreshToken(token);
-        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
-                .orElseThrow(() -> new AuthException(INVALID_TOKEN));
-        return generateOAuthResponse(refreshToken.memberId());
+        return Optional.of(member);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/auth/application/OAuthService.java
+++ b/backend/src/main/java/dev/tripdraw/auth/application/OAuthService.java
@@ -1,0 +1,20 @@
+package dev.tripdraw.auth.application;
+
+import dev.tripdraw.auth.dto.OauthInfo;
+import dev.tripdraw.auth.oauth.OauthClient;
+import dev.tripdraw.auth.oauth.OauthClientProvider;
+import dev.tripdraw.common.auth.OauthType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class OAuthService {
+
+    private final OauthClientProvider oauthClientProvider;
+
+    public OauthInfo request(OauthType oauthType, String oauthToken) {
+        OauthClient oauthClient = oauthClientProvider.provide(oauthType);
+        return oauthClient.requestOauthInfo(oauthToken);
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/auth/application/TokenGenerateService.java
+++ b/backend/src/main/java/dev/tripdraw/auth/application/TokenGenerateService.java
@@ -1,0 +1,39 @@
+package dev.tripdraw.auth.application;
+
+import static dev.tripdraw.auth.exception.AuthExceptionType.INVALID_TOKEN;
+
+import dev.tripdraw.auth.domain.RefreshToken;
+import dev.tripdraw.auth.domain.RefreshTokenRepository;
+import dev.tripdraw.auth.dto.OauthResponse;
+import dev.tripdraw.auth.exception.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TokenGenerateService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public OauthResponse refresh(String token) {
+        jwtTokenProvider.validateRefreshToken(token);
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
+                .orElseThrow(() -> new AuthException(INVALID_TOKEN));
+        return generate(refreshToken.memberId());
+    }
+
+    public OauthResponse generate(Long memberId) {
+        String accessToken = jwtTokenProvider.generateAccessToken(memberId.toString());
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+        refreshTokenRepository.deleteByMemberId(memberId);
+        refreshTokenRepository.save(new RefreshToken(memberId, refreshToken));
+        return new OauthResponse(accessToken, refreshToken);
+    }
+
+    public OauthResponse generateEmptyToken() {
+        return new OauthResponse("", "");
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/auth/application/TokenGenerateService.java
+++ b/backend/src/main/java/dev/tripdraw/auth/application/TokenGenerateService.java
@@ -11,13 +11,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@Transactional
 @Service
 public class TokenGenerateService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    @Transactional
     public OauthResponse refresh(String token) {
         jwtTokenProvider.validateRefreshToken(token);
         RefreshToken refreshToken = refreshTokenRepository.findByToken(token)
@@ -25,6 +25,7 @@ public class TokenGenerateService {
         return generate(refreshToken.memberId());
     }
 
+    @Transactional
     public OauthResponse generate(Long memberId) {
         String accessToken = jwtTokenProvider.generateAccessToken(memberId.toString());
         String refreshToken = jwtTokenProvider.generateRefreshToken();

--- a/backend/src/main/java/dev/tripdraw/auth/config/RefreshTokenConfig.java
+++ b/backend/src/main/java/dev/tripdraw/auth/config/RefreshTokenConfig.java
@@ -7,4 +7,5 @@ public record RefreshTokenConfig(
         String secretKey,
         Long expirationTime
 ) {
+
 }

--- a/backend/src/main/java/dev/tripdraw/auth/config/RefreshTokenConfig.java
+++ b/backend/src/main/java/dev/tripdraw/auth/config/RefreshTokenConfig.java
@@ -7,5 +7,4 @@ public record RefreshTokenConfig(
         String secretKey,
         Long expirationTime
 ) {
-
 }

--- a/backend/src/main/java/dev/tripdraw/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/dev/tripdraw/auth/domain/RefreshToken.java
@@ -28,6 +28,11 @@ public class RefreshToken extends BaseEntity {
     private String token;
 
     public RefreshToken(Long memberId, String token) {
+        this(null, memberId, token);
+    }
+
+    public RefreshToken(Long id, Long memberId, String token) {
+        this.id = id;
         this.memberId = memberId;
         this.token = token;
     }

--- a/backend/src/main/java/dev/tripdraw/auth/presentation/AuthController.java
+++ b/backend/src/main/java/dev/tripdraw/auth/presentation/AuthController.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.auth.presentation;
 
-import dev.tripdraw.auth.application.AuthService;
+import dev.tripdraw.auth.application.AuthFacadeService;
 import dev.tripdraw.auth.dto.OauthRequest;
 import dev.tripdraw.auth.dto.OauthResponse;
 import dev.tripdraw.auth.dto.RegisterRequest;
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class AuthController {
 
-    private final AuthService authService;
+    private final AuthFacadeService authFacadeService;
 
     @Operation(summary = "소셜 로그인 API", description = "소셜 로그인을 합니다.")
     @ApiResponse(
@@ -29,7 +29,7 @@ public class AuthController {
     )
     @PostMapping("/oauth/login")
     public ResponseEntity<OauthResponse> login(@RequestBody OauthRequest oauthRequest) {
-        OauthResponse oauthResponse = authService.login(oauthRequest);
+        OauthResponse oauthResponse = authFacadeService.login(oauthRequest);
         return ResponseEntity.ok(oauthResponse);
     }
 
@@ -40,7 +40,7 @@ public class AuthController {
     )
     @PostMapping("/oauth/register")
     public ResponseEntity<OauthResponse> register(@Valid @RequestBody RegisterRequest registerRequest) {
-        OauthResponse oauthResponse = authService.register(registerRequest);
+        OauthResponse oauthResponse = authFacadeService.register(registerRequest);
         return ResponseEntity.ok(oauthResponse);
     }
 
@@ -51,7 +51,7 @@ public class AuthController {
     )
     @PostMapping("/oauth/refresh")
     public ResponseEntity<OauthResponse> refresh(@Valid @RequestBody TokenRefreshRequest tokenRefreshRequest) {
-        OauthResponse oauthResponse = authService.refresh(tokenRefreshRequest);
+        OauthResponse oauthResponse = authFacadeService.refresh(tokenRefreshRequest);
         return ResponseEntity.ok(oauthResponse);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.common.config;
 
-import dev.tripdraw.auth.presentation.AuthArgumentResolver;
 import dev.tripdraw.auth.application.AuthExtractor;
+import dev.tripdraw.auth.presentation.AuthArgumentResolver;
 import dev.tripdraw.auth.presentation.AuthInterceptor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,6 @@ public class AuthConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .excludePathPatterns("/members/**")
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**")

--- a/backend/src/main/java/dev/tripdraw/member/application/MemberService.java
+++ b/backend/src/main/java/dev/tripdraw/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.member.application;
 
 import dev.tripdraw.auth.application.JwtTokenProvider;
+import dev.tripdraw.common.auth.LoginUser;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.member.dto.MemberSearchResponse;
@@ -26,14 +27,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberSearchResponse findByCode(String code) {
-        Long memberId = Long.valueOf(jwtTokenProvider.extractAccessToken(code));
-        Member member = memberRepository.getById(memberId);
+    public MemberSearchResponse find(LoginUser loginUser) {
+        Member member = memberRepository.getById(loginUser.memberId());
         return MemberSearchResponse.from(member);
     }
 
-    public void deleteByCode(String code) {
-        Long memberId = Long.valueOf(jwtTokenProvider.extractAccessToken(code));
+    public void delete(LoginUser loginUser) {
+        Long memberId = loginUser.memberId();
         postRepository.deleteByMemberId(memberId);
         tripRepository.deleteByMemberId(memberId);
         memberRepository.deleteById(memberId);

--- a/backend/src/main/java/dev/tripdraw/member/presentation/MemberController.java
+++ b/backend/src/main/java/dev/tripdraw/member/presentation/MemberController.java
@@ -1,5 +1,7 @@
 package dev.tripdraw.member.presentation;
 
+import dev.tripdraw.common.auth.Auth;
+import dev.tripdraw.common.auth.LoginUser;
 import dev.tripdraw.member.application.MemberService;
 import dev.tripdraw.member.dto.MemberSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Member", description = "사용자 관련 API 명세")
@@ -26,9 +27,9 @@ public class MemberController {
             responseCode = "200",
             description = "사용자 조회 성공."
     )
-    @GetMapping
-    public ResponseEntity<MemberSearchResponse> findByCode(@RequestParam String code) {
-        MemberSearchResponse response = memberService.findByCode(code);
+    @GetMapping("/me")
+    public ResponseEntity<MemberSearchResponse> findByCode(@Auth LoginUser loginUser) {
+        MemberSearchResponse response = memberService.find(loginUser);
         return ResponseEntity.ok(response);
     }
 
@@ -37,9 +38,9 @@ public class MemberController {
             responseCode = "204",
             description = "사용자 삭제 성공."
     )
-    @DeleteMapping
-    public ResponseEntity<Void> delete(@RequestParam String code) {
-        memberService.deleteByCode(code);
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> delete(@Auth LoginUser loginUser) {
+        memberService.delete(loginUser);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
@@ -13,14 +13,20 @@ import dev.tripdraw.auth.dto.TokenRefreshRequest;
 import dev.tripdraw.auth.oauth.OauthClientProvider;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
-import dev.tripdraw.test.ServiceTest;
 import dev.tripdraw.test.TestKakaoApiClient;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@ServiceTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Transactional
+@SpringBootTest
 class AuthFacadeServiceTest {
 
     @Autowired

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
@@ -1,0 +1,114 @@
+package dev.tripdraw.auth.application;
+
+import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.when;
+
+import dev.tripdraw.auth.domain.RefreshToken;
+import dev.tripdraw.auth.domain.RefreshTokenRepository;
+import dev.tripdraw.auth.dto.OauthRequest;
+import dev.tripdraw.auth.dto.OauthResponse;
+import dev.tripdraw.auth.dto.RegisterRequest;
+import dev.tripdraw.auth.dto.TokenRefreshRequest;
+import dev.tripdraw.auth.oauth.OauthClientProvider;
+import dev.tripdraw.member.domain.Member;
+import dev.tripdraw.member.domain.MemberRepository;
+import dev.tripdraw.test.ServiceTest;
+import dev.tripdraw.test.TestKakaoApiClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@ServiceTest
+class AuthFacadeServiceTest {
+
+    @Autowired
+    private AuthFacadeService authFacadeService;
+
+    @MockBean
+    private OauthClientProvider oauthClientProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        when(oauthClientProvider.provide(KAKAO)).thenReturn(new TestKakaoApiClient());
+    }
+
+    @Test
+    void 가입된_회원이_카카오_소셜_로그인하면_토큰이_포함된_응답을_반환한다() {
+        // given
+        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+
+        // when
+        OauthResponse response = authFacadeService.login(oauthRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.accessToken()).isNotEmpty();
+            softly.assertThat(response.refreshToken()).isNotEmpty();
+        });
+    }
+
+    @Test
+    void 신규_회원이_로그인하면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
+        // given
+        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+
+        // when
+        OauthResponse response = authFacadeService.login(oauthRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.accessToken()).isEmpty();
+            softly.assertThat(response.refreshToken()).isEmpty();
+        });
+    }
+
+    @Test
+    void 신규_회원의_닉네임을_등록하면_토큰이_포함된_응답을_반환한다() {
+        // given
+        Member member = Member.of("kakaoId", KAKAO);
+        memberRepository.save(member);
+
+        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
+
+        // when
+        OauthResponse response = authFacadeService.register(registerRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.accessToken()).isNotEmpty();
+            softly.assertThat(response.refreshToken()).isNotEmpty();
+        });
+    }
+
+    @Test
+    void Refresh_토큰을_입력받아_Access_토큰과_Refresh_토큰을_재발급한다() {
+        // given
+        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+        refreshTokenRepository.save(new RefreshToken(member.id(), refreshToken));
+        TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest(refreshToken);
+
+        // when
+        OauthResponse response = authFacadeService.refresh(tokenRefreshRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.accessToken()).isNotEmpty();
+            softly.assertThat(response.refreshToken()).isNotEmpty();
+            softly.assertThat(refreshTokenRepository.findByToken(refreshToken)).isEmpty();
+            softly.assertThat(refreshTokenRepository.findByToken(response.refreshToken())).isPresent();
+        });
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
@@ -2,7 +2,7 @@ package dev.tripdraw.auth.application;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import dev.tripdraw.auth.domain.RefreshToken;
 import dev.tripdraw.auth.domain.RefreshTokenRepository;
@@ -46,7 +46,7 @@ class AuthFacadeServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(oauthClientProvider.provide(KAKAO)).thenReturn(new TestKakaoApiClient());
+        given(oauthClientProvider.provide(KAKAO)).willReturn(new TestKakaoApiClient());
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
@@ -1,23 +1,20 @@
 package dev.tripdraw.auth.application;
 
-import static dev.tripdraw.auth.exception.AuthExceptionType.EXPIRED_REFRESH_TOKEN;
-import static dev.tripdraw.auth.exception.AuthExceptionType.INVALID_TOKEN;
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.member.exception.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
-import static dev.tripdraw.test.fixture.AuthFixture.만료된_토큰_생성용_ACCESS_TOKEN_설정;
-import static dev.tripdraw.test.fixture.AuthFixture.만료된_토큰_생성용_REFRESH_TOKEN_설정;
 import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import dev.tripdraw.auth.domain.RefreshToken;
-import dev.tripdraw.auth.domain.RefreshTokenRepository;
 import dev.tripdraw.auth.dto.OauthInfo;
-import dev.tripdraw.auth.dto.OauthResponse;
-import dev.tripdraw.auth.exception.AuthException;
 import dev.tripdraw.common.auth.OauthType;
+import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.member.exception.MemberException;
 import java.util.Optional;
@@ -36,49 +33,52 @@ class AuthServiceTest {
     @Autowired
     private AuthService authService;
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-
     @MockBean
     private MemberRepository memberRepository;
 
-    @MockBean
-    private RefreshTokenRepository refreshTokenRepository;
+    private final OauthInfo oauthInfo = new OauthInfo("id", KAKAO);
 
     @Test
-    void 신규_회원이_로그인하면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
+    void 신규_회원이_로그인하면_회원을_저장_후_빈_회원을_반환한다() {
         // given
         given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
                 .willReturn(Optional.empty());
 
-        OauthInfo oauthInfo = new OauthInfo("id", KAKAO);
-
         // when
-        OauthResponse response = authService.login(oauthInfo);
+        Optional<Member> member = authService.login(oauthInfo);
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(response.accessToken()).isEmpty();
-            softly.assertThat(response.refreshToken()).isEmpty();
+            softly.assertThat(member).isNotPresent();
+            verify(memberRepository, times(1)).save(any(Member.class));
         });
     }
 
     @Test
-    void 신규_회원의_닉네임을_등록하면_토큰이_포함된_응답을_반환한다() {
+    void 기존의_회원이_로그인하면_회원_정보를_반환한다() {
+        // given
+        Member 사용자 = 사용자();
+        given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
+                .willReturn(Optional.of(사용자));
+
+        // when
+        Optional<Member> member = authService.login(oauthInfo);
+
+        // then
+        assertThat(member).isPresent();
+    }
+
+    @Test
+    void 신규_회원의_닉네임을_등록_후_회원_정보를_반환한다() {
         // given
         given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
                 .willReturn(Optional.of(사용자()));
 
-        OauthInfo oauthInfo = new OauthInfo("id", KAKAO);
-
         // when
-        OauthResponse response = authService.register(oauthInfo, "통후추");
+        Optional<Member> member = authService.register(oauthInfo, "통후추");
 
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(response.accessToken()).isNotEmpty();
-            softly.assertThat(response.refreshToken()).isNotEmpty();
-        });
+        assertThat(member).isPresent();
     }
 
     @Test
@@ -87,56 +87,21 @@ class AuthServiceTest {
         given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
                 .willReturn(Optional.empty());
 
-        OauthInfo unregisteredOauthInfo = new OauthInfo("id", KAKAO);
-
         // expect
-        assertThatThrownBy(() -> authService.register(unregisteredOauthInfo, "통후추"))
+        assertThatThrownBy(() -> authService.register(oauthInfo, "통후추"))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.message());
     }
 
     @Test
-    void Refresh_토큰_재발급시_입력받은_Refresh_토큰이_만료된_경우_예외가_발생한다() {
+    void 신규_회원의_닉네임을_등록할_때_이미_존재하는_닉네임이라면_예외가_발생한다() {
         // given
-        JwtTokenProvider expiredTokenProvider = new JwtTokenProvider(
-                만료된_토큰_생성용_ACCESS_TOKEN_설정(),
-                만료된_토큰_생성용_REFRESH_TOKEN_설정()
-        );
-        String expiredToken = expiredTokenProvider.generateRefreshToken();
+        given(memberRepository.existsByNickname(any(String.class)))
+                .willReturn(true);
 
         // expect
-        assertThatThrownBy(() -> authService.refresh(expiredToken))
-                .isInstanceOf(AuthException.class)
-                .hasMessage(EXPIRED_REFRESH_TOKEN.message());
-    }
-
-    @Test
-    void Refresh_토큰_재발급시_입력받은_Refresh_토큰이_존재하지_않는_토큰인_경우_예외가_발생한다() {
-        // given
-        given(refreshTokenRepository.findByToken(any(String.class))).willReturn(Optional.empty());
-        String token = jwtTokenProvider.generateRefreshToken();
-
-        // expect
-        assertThatThrownBy(() -> authService.refresh(token))
-                .isInstanceOf(AuthException.class)
-                .hasMessage(INVALID_TOKEN.message());
-    }
-
-    @Test
-    void Refresh_토큰을_입력받아_Access_토큰과_Refresh_토큰을_재발급한다() {
-        // given
-        String refreshToken = jwtTokenProvider.generateRefreshToken();
-        given(refreshTokenRepository.findByToken(any(String.class)))
-                .willReturn(Optional.of(new RefreshToken(1L, 1L, refreshToken)));
-
-        // when
-        OauthResponse response = authService.refresh(refreshToken);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(response.accessToken()).isNotEmpty();
-            softly.assertThat(response.refreshToken()).isNotEmpty();
-            softly.assertThat(response.refreshToken()).isNotEqualTo(refreshToken);
-        });
+        assertThatThrownBy(() -> authService.register(oauthInfo, "통후추"))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(DUPLICATE_NICKNAME.message());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
@@ -21,19 +21,20 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-    @Autowired
+    @InjectMocks
     private AuthService authService;
 
-    @MockBean
+    @Mock
     private MemberRepository memberRepository;
 
     private final OauthInfo oauthInfo = new OauthInfo("id", KAKAO);

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
@@ -1,79 +1,60 @@
 package dev.tripdraw.auth.application;
 
 import static dev.tripdraw.auth.exception.AuthExceptionType.EXPIRED_REFRESH_TOKEN;
+import static dev.tripdraw.auth.exception.AuthExceptionType.INVALID_TOKEN;
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
-import static dev.tripdraw.member.exception.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
 import static dev.tripdraw.test.fixture.AuthFixture.만료된_토큰_생성용_ACCESS_TOKEN_설정;
 import static dev.tripdraw.test.fixture.AuthFixture.만료된_토큰_생성용_REFRESH_TOKEN_설정;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import dev.tripdraw.auth.domain.RefreshToken;
 import dev.tripdraw.auth.domain.RefreshTokenRepository;
-import dev.tripdraw.auth.dto.OauthRequest;
+import dev.tripdraw.auth.dto.OauthInfo;
 import dev.tripdraw.auth.dto.OauthResponse;
-import dev.tripdraw.auth.dto.RegisterRequest;
-import dev.tripdraw.auth.dto.TokenRefreshRequest;
 import dev.tripdraw.auth.exception.AuthException;
-import dev.tripdraw.auth.oauth.OauthClientProvider;
-import dev.tripdraw.member.domain.Member;
+import dev.tripdraw.common.auth.OauthType;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.member.exception.MemberException;
-import dev.tripdraw.test.ServiceTest;
-import dev.tripdraw.test.TestKakaoApiClient;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@ServiceTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest
 class AuthServiceTest {
 
     @Autowired
     private AuthService authService;
 
-    @MockBean
-    private OauthClientProvider oauthClientProvider;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private RefreshTokenRepository refreshTokenRepository;
-
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    @BeforeEach
-    void setUp() {
-        when(oauthClientProvider.provide(KAKAO)).thenReturn(new TestKakaoApiClient());
-    }
+    @MockBean
+    private MemberRepository memberRepository;
 
-    @Test
-    void 가입된_회원이_카카오_소셜_로그인하면_토큰이_포함된_응답을_반환한다() {
-        // given
-        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
-
-        // when
-        OauthResponse response = authService.login(oauthRequest);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(response.accessToken()).isNotEmpty();
-            softly.assertThat(response.refreshToken()).isNotEmpty();
-        });
-    }
+    @MockBean
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Test
     void 신규_회원이_로그인하면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
         // given
-        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+        given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
+                .willReturn(Optional.empty());
+
+        OauthInfo oauthInfo = new OauthInfo("id", KAKAO);
 
         // when
-        OauthResponse response = authService.login(oauthRequest);
+        OauthResponse response = authService.login(oauthInfo);
 
         // then
         assertSoftly(softly -> {
@@ -85,13 +66,13 @@ class AuthServiceTest {
     @Test
     void 신규_회원의_닉네임을_등록하면_토큰이_포함된_응답을_반환한다() {
         // given
-        Member member = Member.of("kakaoId", KAKAO);
-        memberRepository.save(member);
+        given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
+                .willReturn(Optional.of(사용자()));
 
-        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
+        OauthInfo oauthInfo = new OauthInfo("id", KAKAO);
 
         // when
-        OauthResponse response = authService.register(registerRequest);
+        OauthResponse response = authService.register(oauthInfo, "통후추");
 
         // then
         assertSoftly(softly -> {
@@ -103,61 +84,59 @@ class AuthServiceTest {
     @Test
     void 신규_회원의_닉네임을_등록할_때_회원이_존재하지_않으면_예외가_발생한다() {
         // given
-        RegisterRequest registerRequest = new RegisterRequest("저장안된후추", KAKAO, "oauth.kakao.token");
+        given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
+                .willReturn(Optional.empty());
+
+        OauthInfo unregisteredOauthInfo = new OauthInfo("id", KAKAO);
 
         // expect
-        assertThatThrownBy(() -> authService.register(registerRequest))
+        assertThatThrownBy(() -> authService.register(unregisteredOauthInfo, "통후추"))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.message());
     }
 
     @Test
-    void 신규_회원의_닉네임을_등록할_때_이미_존재하는_닉네임이면_예외가_발생한다() {
+    void Refresh_토큰_재발급시_입력받은_Refresh_토큰이_만료된_경우_예외가_발생한다() {
         // given
-        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
-
-        // expect
-        assertThatThrownBy(() -> authService.register(registerRequest))
-                .isInstanceOf(MemberException.class)
-                .hasMessage(DUPLICATE_NICKNAME.message());
-    }
-
-    @Test
-    void Refresh_토큰_재발급시_입력받은_토큰이_만료되는_경우_예외가_발생한다() {
-        // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
         JwtTokenProvider expiredTokenProvider = new JwtTokenProvider(
                 만료된_토큰_생성용_ACCESS_TOKEN_설정(),
                 만료된_토큰_생성용_REFRESH_TOKEN_설정()
         );
         String expiredToken = expiredTokenProvider.generateRefreshToken();
-        refreshTokenRepository.save(new RefreshToken(member.id(), expiredToken));
-        TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest(expiredToken);
 
         // expect
-        assertThatThrownBy(() -> authService.refresh(tokenRefreshRequest))
+        assertThatThrownBy(() -> authService.refresh(expiredToken))
                 .isInstanceOf(AuthException.class)
                 .hasMessage(EXPIRED_REFRESH_TOKEN.message());
     }
 
     @Test
+    void Refresh_토큰_재발급시_입력받은_Refresh_토큰이_존재하지_않는_토큰인_경우_예외가_발생한다() {
+        // given
+        given(refreshTokenRepository.findByToken(any(String.class))).willReturn(Optional.empty());
+        String token = jwtTokenProvider.generateRefreshToken();
+
+        // expect
+        assertThatThrownBy(() -> authService.refresh(token))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_TOKEN.message());
+    }
+
+    @Test
     void Refresh_토큰을_입력받아_Access_토큰과_Refresh_토큰을_재발급한다() {
         // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
         String refreshToken = jwtTokenProvider.generateRefreshToken();
-        refreshTokenRepository.save(new RefreshToken(member.id(), refreshToken));
-        TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest(refreshToken);
+        given(refreshTokenRepository.findByToken(any(String.class)))
+                .willReturn(Optional.of(new RefreshToken(1L, 1L, refreshToken)));
 
         // when
-        OauthResponse response = authService.refresh(tokenRefreshRequest);
+        OauthResponse response = authService.refresh(refreshToken);
 
         // then
         assertSoftly(softly -> {
             softly.assertThat(response.accessToken()).isNotEmpty();
             softly.assertThat(response.refreshToken()).isNotEmpty();
-            softly.assertThat(refreshTokenRepository.findByToken(refreshToken)).isEmpty();
-            softly.assertThat(refreshTokenRepository.findByToken(response.refreshToken())).isPresent();
+            softly.assertThat(response.refreshToken()).isNotEqualTo(refreshToken);
         });
     }
 }

--- a/backend/src/test/java/dev/tripdraw/auth/application/OAuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/OAuthServiceTest.java
@@ -1,0 +1,48 @@
+package dev.tripdraw.auth.application;
+
+import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.when;
+
+import dev.tripdraw.auth.dto.OauthInfo;
+import dev.tripdraw.auth.oauth.OauthClientProvider;
+import dev.tripdraw.test.TestKakaoApiClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest
+class OAuthServiceTest {
+
+    @Autowired
+    private OAuthService oAuthService;
+
+    @MockBean
+    private OauthClientProvider oauthClientProvider;
+
+    @BeforeEach
+    void setUp() {
+        when(oauthClientProvider.provide(KAKAO)).thenReturn(new TestKakaoApiClient());
+    }
+
+    @Test
+    void Oauth_공통_정보를_반환한다() {
+        // given
+        String oauthToken = "oauth.kakao.token";
+
+        // when
+        OauthInfo oauthInfo = oAuthService.request(KAKAO, oauthToken);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(oauthInfo.oauthId()).isEqualTo("kakaoId");
+            softly.assertThat(oauthInfo.oauthType()).isEqualTo(KAKAO);
+        });
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/auth/application/OAuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/OAuthServiceTest.java
@@ -11,19 +11,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class OAuthServiceTest {
 
-    @Autowired
+    @InjectMocks
     private OAuthService oAuthService;
 
-    @MockBean
+    @Mock
     private OauthClientProvider oauthClientProvider;
 
     @BeforeEach

--- a/backend/src/test/java/dev/tripdraw/auth/application/TokenGenerateServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/TokenGenerateServiceTest.java
@@ -1,0 +1,92 @@
+package dev.tripdraw.auth.application;
+
+import static dev.tripdraw.auth.exception.AuthExceptionType.INVALID_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import dev.tripdraw.auth.domain.RefreshToken;
+import dev.tripdraw.auth.domain.RefreshTokenRepository;
+import dev.tripdraw.auth.dto.OauthResponse;
+import dev.tripdraw.auth.exception.AuthException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest
+class TokenGenerateServiceTest {
+
+    @Autowired
+    private TokenGenerateService tokenGenerateService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void refreshToken을_발급하여_저장하고_Access_토큰과_Refresh_토큰을_반환한다() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        OauthResponse result = tokenGenerateService.generate(memberId);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.accessToken()).isNotEmpty();
+            softly.assertThat(result.refreshToken()).isNotEmpty();
+            verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+        });
+    }
+
+    @Test
+    void Refresh_토큰_재발급시_입력받은_Refresh_토큰이_존재하지_않는_토큰인_경우_예외가_발생한다() {
+        // given
+        given(refreshTokenRepository.findByToken(any(String.class))).willReturn(Optional.empty());
+        String token = jwtTokenProvider.generateRefreshToken();
+
+        // expect
+        assertThatThrownBy(() -> tokenGenerateService.refresh(token))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_TOKEN.message());
+    }
+
+    @Test
+    void Refresh_토큰을_입력받아_Access_토큰과_Refresh_토큰을_재발급한다() {
+        // given
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+        given(refreshTokenRepository.findByToken(any(String.class)))
+                .willReturn(Optional.of(new RefreshToken(1L, 1L, refreshToken)));
+
+        // when
+        OauthResponse result = tokenGenerateService.refresh(refreshToken);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.accessToken()).isNotEmpty();
+            softly.assertThat(result.refreshToken()).isNotEmpty();
+            softly.assertThat(result.refreshToken()).isNotEqualTo(refreshToken);
+        });
+    }
+
+    @Test
+    void 빈_토큰을_발급한다() {
+        // given
+        OauthResponse emptyToken = new OauthResponse("", "");
+
+        // expect
+        assertThat(tokenGenerateService.generateEmptyToken()).isEqualTo(emptyToken);
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/auth/application/TokenGenerateServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/TokenGenerateServiceTest.java
@@ -1,6 +1,8 @@
 package dev.tripdraw.auth.application;
 
 import static dev.tripdraw.auth.exception.AuthExceptionType.INVALID_TOKEN;
+import static dev.tripdraw.test.fixture.AuthFixture.테스트_ACCESS_TOKEN_설정;
+import static dev.tripdraw.test.fixture.AuthFixture.테스트_REFRESH_TOKEN_설정;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -17,22 +19,27 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class TokenGenerateServiceTest {
 
-    @Autowired
+    @InjectMocks
     private TokenGenerateService tokenGenerateService;
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    @Spy
+    private JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
+            테스트_ACCESS_TOKEN_설정(),
+            테스트_REFRESH_TOKEN_설정()
+    );
 
-    @MockBean
+    @Mock
     private RefreshTokenRepository refreshTokenRepository;
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
@@ -1,0 +1,11 @@
+package dev.tripdraw.test.fixture;
+
+import dev.tripdraw.common.auth.OauthType;
+import dev.tripdraw.member.domain.Member;
+
+public class MemberFixture {
+
+    public static Member 사용자() {
+        return new Member(1L, "통후추", "", OauthType.KAKAO);
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈

- closed #349 

### 📁 작업 설명

- OAuth API 호출에 해당하는 부분을 Facade를 이용해서 트랜잭션에서 제외했습니다.

다음과 같은 구조로 되어있습니다.

```mermaid
graph LR
	A[AuthFacadeService] --> OAuthService
	A --> AuthService
	A --> TokenGenerateService
```

로그인 후 토큰 발급까지는 Transaction으로 묶어야 해서, TransactionTemplate을 사용했습니다.

