### PR TITLE
[feat] 비동기 예외 처리 기능 추가 (#368)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/common/async/AsyncConfigurationProperties.java
+++ b/backend/src/main/java/dev/tripdraw/common/async/AsyncConfigurationProperties.java
@@ -1,0 +1,11 @@
+package dev.tripdraw.common.async;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.task.execution.pool")
+public record AsyncConfigurationProperties(
+        int coreSize,
+        int maxSize,
+        int queueCapacity
+) {
+}

--- a/backend/src/main/java/dev/tripdraw/common/async/AsyncExceptionHandler.java
+++ b/backend/src/main/java/dev/tripdraw/common/async/AsyncExceptionHandler.java
@@ -1,0 +1,19 @@
+package dev.tripdraw.common.async;
+
+import static dev.tripdraw.common.log.MdcToken.REQUEST_ID;
+
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    private static final String LOG_FORMAT = "[%s] %s";
+
+    @Override
+    public void handleUncaughtException(Throwable throwable, Method method, Object... obj) {
+        log.info(String.format(LOG_FORMAT, MDC.get(REQUEST_ID.key()), throwable.getMessage()), throwable);
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/common/async/MdcTaskDecorator.java
+++ b/backend/src/main/java/dev/tripdraw/common/async/MdcTaskDecorator.java
@@ -1,0 +1,17 @@
+package dev.tripdraw.common.async;
+
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(final Runnable runnable) {
+        Map<String, String> threadContext = MDC.getCopyOfContextMap();
+        return () -> {
+            MDC.setContextMap(threadContext);
+            runnable.run();
+        };
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/common/config/AsyncConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AsyncConfig.java
@@ -1,9 +1,37 @@
 package dev.tripdraw.common.config;
 
+import dev.tripdraw.common.async.AsyncConfigurationProperties;
+import dev.tripdraw.common.async.AsyncExceptionHandler;
+import dev.tripdraw.common.async.MdcTaskDecorator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+@RequiredArgsConstructor
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
+
+    private final AsyncConfigurationProperties properties;
+
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(properties.coreSize());
+        executor.setMaxPoolSize(properties.maxSize());
+        executor.setQueueCapacity(properties.queueCapacity());
+        executor.setTaskDecorator(new MdcTaskDecorator());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -4,6 +4,13 @@ spring:
     username: sa
     password:
 
+  task:
+    execution:
+      pool:
+        core-size: 8
+        queue-capacity: 100
+        max-size: 16
+
   h2:
     console:
       enabled: true


### PR DESCRIPTION
### 📌 관련 이슈

- closed #368 

### 📁 작업 설명

현재 경로 이미지 생성 기능은 비동기로 처리되고 있습니다.
로그를 확인하는 도중 `@Async`가 적용된 메서드에서 예외가 발생하는 경우 로그가 정상적으로 출력되지 않는 문제를 확인했습니다.

<img width="1118" alt="스크린샷 2023-09-18 오전 11 40 03" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/58586537/aca148aa-b381-4da2-ac73-ffb97557262a">

확인해보니 Spring의 `@ControllerAdvice` + `@ExceptionHandler`의 경우 동기 예외만 처리해주고, 비동기 예외를 처리해주지 않았습니다.
따라서 Spring에서 지원해주는 AsyncUncaughtExceptionHandler 인터페이스를 구현해서 예외를 처리해주는 클래스를 생성하였습니다.

### 비동기 예외처리

```java
@Slf4j
public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {

    private static final String LOG_FORMAT = "[%s] %s";

    @Override
    public void handleUncaughtException(Throwable throwable, Method method, Object... obj) {
        log.info(String.format(LOG_FORMAT, MDC.get(REQUEST_ID.key()), throwable.getMessage()), throwable);
    }
}
```

해당 AsyncExceptionHandler의 경우 AsyncConfigurer를 구현한 Configuration 클래스를 사용하여 등록할 수 있습니다.
getAsyncUncaughtExceptionHandler 메서드를 오버라이딩하여 이전에 생성해준 AsyncExceptionHandler를 반환해주도록 설정했습니다.
이렇게 설정한다면 예외가 발생하는 경우 AsyncUncaughtExceptionHandler의 구현체인 AsyncExceptionHandler가 예외를 잡아서 처리를 해주었습니다.

```java
@EnableAsync
@Configuration
public class AsyncConfig implements AsyncConfigurer {

    @Override
    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
        return new AsyncExceptionHandler();
    }
}
```

### MDC 정보 연동 문제

기존 예외가 발생할 때 실행 흐름을 추적하기 위해 MDC(Mapped Diagnostic Context) 를 사용하고 있었습니다.
비동기 처리의 경우 별도의 스레드에서 동작하기 때문에 ThreadLocal 기반으로 동작하는 MDC의 정보를 얻어올 수 없었습니다.

이를 적절하게 Decorator 클래스를 설정하여 MDC의 정보를 복사해서 넘겨줄 수 있습니다.

다음과 같이 TaskDecorator를 구현한 클래스를 하나 생성해줍니다.
Task가 실행되기 전 MDC의 정보를 복사하도록 설정했습니다.

```java
public class MdcTaskDecorator implements TaskDecorator {

    @Override
    public Runnable decorate(final Runnable runnable) {
        Map<String, String> threadContext = MDC.getCopyOfContextMap();
        return () -> {
            MDC.setContextMap(threadContext);
            runnable.run();
        };
    }
}
```

해당 Decorator 클래스를 설정 파일에 등록해줍니다.

```java
@RequiredArgsConstructor
@EnableAsync
@Configuration
public class AsyncConfig implements AsyncConfigurer {

    private final AsyncConfigurationProperties properties;

    @Bean
    public ThreadPoolTaskExecutor taskExecutor() {
        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
        executor.setCorePoolSize(properties.coreSize());
        executor.setMaxPoolSize(properties.maxSize());
        executor.setQueueCapacity(properties.queueCapacity());
        
        executor.setTaskDecorator(new MdcTaskDecorator());
        executor.setWaitForTasksToCompleteOnShutdown(true);
        executor.initialize();
        return executor;
    }

    @Override
    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
        return new AsyncExceptionHandler();
    }
}
```

설정 후에는 정상적으로 MDC에 들어가있는 UUID가 출력되었습니다!

<img width="1310" alt="스크린샷 2023-09-18 오전 11 48 15" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/58586537/94355309-9203-4df5-8510-85a26c29d27f">

