### PR TITLE
[feat] 감상 조회시 다른 유저도 감상을 조회할 수 있도록 변경 (#388)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -105,7 +105,7 @@ public class PostController {
             @Auth LoginUser loginUser,
             @PathVariable Long postId
     ) {
-        PostResponse response = postService.read(loginUser, postId);
+        PostResponse response = postService.read(postId);
         return ResponseEntity.ok(response);
     }
 
@@ -119,7 +119,7 @@ public class PostController {
             @Auth LoginUser loginUser,
             @PathVariable Long tripId
     ) {
-        PostsResponse response = postService.readAllByTripId(loginUser, tripId);
+        PostsResponse response = postService.readAllByTripId(tripId);
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
### 📌 관련 이슈

- closed #388 

### 📁 작업 설명

- 감상 조회시 다른 유저도 감상을 조회할 수 있도록 변경했습니다.

### 💻 주의사항
- 현재 인증을 위해서, PostController에서 감상을 조회하는 기능이 포함된 메서드들의 파라미터로 `@Auth LoginUser loginUser`가 남아있습니다.