### PR TITLE
[refactor] 회원 삭제 시 쿼리 변경 (#398)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/common/async/AsyncConfigurationProperties.java
+++ b/backend/src/main/java/dev/tripdraw/common/async/AsyncConfigurationProperties.java
@@ -1,0 +1,11 @@
+package dev.tripdraw.common.async;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.task.execution.pool")
+public record AsyncConfigurationProperties(
+        int coreSize,
+        int maxSize,
+        int queueCapacity
+) {
+}

--- a/backend/src/main/java/dev/tripdraw/common/async/AsyncExceptionHandler.java
+++ b/backend/src/main/java/dev/tripdraw/common/async/AsyncExceptionHandler.java
@@ -1,0 +1,19 @@
+package dev.tripdraw.common.async;
+
+import static dev.tripdraw.common.log.MdcToken.REQUEST_ID;
+
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    private static final String LOG_FORMAT = "[%s] %s";
+
+    @Override
+    public void handleUncaughtException(Throwable throwable, Method method, Object... obj) {
+        log.info(String.format(LOG_FORMAT, MDC.get(REQUEST_ID.key()), throwable.getMessage()), throwable);
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/common/async/MdcTaskDecorator.java
+++ b/backend/src/main/java/dev/tripdraw/common/async/MdcTaskDecorator.java
@@ -1,0 +1,17 @@
+package dev.tripdraw.common.async;
+
+import java.util.Map;
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(final Runnable runnable) {
+        Map<String, String> threadContext = MDC.getCopyOfContextMap();
+        return () -> {
+            MDC.setContextMap(threadContext);
+            runnable.run();
+        };
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/common/config/AsyncConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AsyncConfig.java
@@ -1,9 +1,37 @@
 package dev.tripdraw.common.config;
 
+import dev.tripdraw.common.async.AsyncConfigurationProperties;
+import dev.tripdraw.common.async.AsyncExceptionHandler;
+import dev.tripdraw.common.async.MdcTaskDecorator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+@RequiredArgsConstructor
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
+
+    private final AsyncConfigurationProperties properties;
+
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(properties.coreSize());
+        executor.setMaxPoolSize(properties.maxSize());
+        executor.setQueueCapacity(properties.queueCapacity());
+        executor.setTaskDecorator(new MdcTaskDecorator());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
 }

--- a/backend/src/main/java/dev/tripdraw/draw/application/RouteImageGenerator.java
+++ b/backend/src/main/java/dev/tripdraw/draw/application/RouteImageGenerator.java
@@ -23,8 +23,8 @@ public class RouteImageGenerator {
             List<Double> pointedLongitudes
     ) {
         RouteImageDrawer routeImageDrawer = RouteImageDrawer.from(IMAGE_SIZE);
-        Coordinates coordinates = Coordinates.of(latitudes, longitudes);
-        Coordinates pointedCoordinates = Coordinates.of(pointedLatitudes, pointedLongitudes);
+        Coordinates coordinates = Coordinates.of(longitudes, latitudes);
+        Coordinates pointedCoordinates = Coordinates.of(pointedLongitudes, pointedLatitudes);
 
         drawImage(coordinates, routeImageDrawer, pointedCoordinates);
 

--- a/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
@@ -3,11 +3,11 @@ package dev.tripdraw.post.domain;
 import static dev.tripdraw.post.exception.PostExceptionType.POST_NOT_FOUND;
 
 import dev.tripdraw.post.exception.PostException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -19,5 +19,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                 .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 
-    void deleteByMemberId(Long memberId);
+    @Modifying
+    @Query("DELETE FROM Post p WHERE p.member.id = :memberId")
+    void deleteByMemberId(@Param(value = "memberId") Long memberId);
 }

--- a/backend/src/main/java/dev/tripdraw/trip/application/TripDeleteEventHandler.java
+++ b/backend/src/main/java/dev/tripdraw/trip/application/TripDeleteEventHandler.java
@@ -1,21 +1,24 @@
 package dev.tripdraw.trip.application;
 
 import dev.tripdraw.member.domain.MemberDeleteEvent;
+import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.TripRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+@RequiredArgsConstructor
 @Component
 public class TripDeleteEventHandler {
 
     private final TripRepository tripRepository;
-
-    public TripDeleteEventHandler(TripRepository tripRepository) {
-        this.tripRepository = tripRepository;
-    }
+    private final PointRepository pointRepository;
 
     @EventListener
     public void deletePostByMemberId(MemberDeleteEvent event) {
+        List<Long> tripIds = tripRepository.findAllTripIdsByMemberId(event.memberId());
+        pointRepository.deleteByTripIds(tripIds);
         tripRepository.deleteByMemberId(event.memberId());
     }
 }

--- a/backend/src/main/java/dev/tripdraw/trip/domain/PointRepository.java
+++ b/backend/src/main/java/dev/tripdraw/trip/domain/PointRepository.java
@@ -3,7 +3,11 @@ package dev.tripdraw.trip.domain;
 import static dev.tripdraw.trip.exception.TripExceptionType.POINT_NOT_FOUND;
 
 import dev.tripdraw.trip.exception.TripException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 
@@ -11,4 +15,8 @@ public interface PointRepository extends JpaRepository<Point, Long> {
         return findById(id)
                 .orElseThrow(() -> new TripException(POINT_NOT_FOUND));
     }
+
+    @Modifying
+    @Query("DELETE FROM Point p WHERE p.trip.id IN :tripIds")
+    void deleteByTripIds(@Param(value = "tripIds") List<Long> tripIds);
 }

--- a/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
+++ b/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
@@ -6,6 +6,7 @@ import dev.tripdraw.trip.exception.TripException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,7 +14,9 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
 
     List<Trip> findAllByMemberId(Long memberId);
 
-    void deleteByMemberId(Long memberId);
+    @Modifying
+    @Query("DELETE FROM Trip t WHERE t.member.id = :memberId")
+    void deleteByMemberId(@Param(value = "memberId") Long memberId);
 
     default Trip getById(Long id) {
         return findById(id)

--- a/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
+++ b/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
@@ -27,4 +27,6 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
         return findTripWithPoints(tripId)
                 .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
     }
+
+    List<Long> findAllTripIdsByMemberId(Long memberId);
 }

--- a/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
+++ b/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
@@ -28,5 +28,6 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
                 .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
     }
 
-    List<Long> findAllTripIdsByMemberId(Long memberId);
+    @Query("SELECT t.id FROM Trip t WHERE t.member.id = :memberId")
+    List<Long> findAllTripIdsByMemberId(@Param(value = "memberId") Long memberId);
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -4,6 +4,13 @@ spring:
     username: sa
     password:
 
+  task:
+    execution:
+      pool:
+        core-size: 8
+        queue-capacity: 100
+        max-size: 16
+
   h2:
     console:
       enabled: true

--- a/backend/src/test/java/dev/tripdraw/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/member/application/MemberServiceTest.java
@@ -50,7 +50,7 @@ class MemberServiceTest {
         member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
         trip = tripRepository.save(new Trip(TripName.from("통후추의 여행"), member));
         Point point = new Point(3.14, 5.25, LocalDateTime.now());
-        trip.add(point);
+        point.setTrip(trip);
         postRepository.save(new Post(
                 "제목",
                 point,

--- a/backend/src/test/java/dev/tripdraw/post/domain/PostRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/domain/PostRepositoryTest.java
@@ -71,13 +71,13 @@ class PostRepositoryTest {
     void 회원_ID로_감상을_삭제한다() {
         // given
         Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member, trip.id());
-        postRepository.save(post);
+        Long postId = postRepository.save(post).id();
 
         // when
         postRepository.deleteByMemberId(member.id());
 
         // then
-        assertThat(postRepository.findById(post.id())).isEmpty();
+        assertThat(postRepository.existsById(postId)).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripDeleteEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripDeleteEventHandlerTest.java
@@ -1,10 +1,13 @@
 package dev.tripdraw.trip.application;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import dev.tripdraw.member.domain.MemberDeleteEvent;
+import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.TripRepository;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,9 @@ class TripDeleteEventHandlerTest {
     @Mock
     private TripRepository tripRepository;
 
+    @Mock
+    private PointRepository pointRepository;
+
     @InjectMocks
     private TripDeleteEventHandler tripDeleteEventHandler;
 
@@ -29,6 +35,10 @@ class TripDeleteEventHandlerTest {
         // given
         MemberDeleteEvent memberDeleteEvent = new MemberDeleteEvent(1L);
 
+        List<Long> tripIds = List.of(1L);
+        given(tripRepository.findAllTripIdsByMemberId(memberDeleteEvent.memberId()))
+                .willReturn(tripIds);
+
         // when
         tripDeleteEventHandler.deletePostByMemberId(memberDeleteEvent);
         
@@ -36,5 +46,8 @@ class TripDeleteEventHandlerTest {
         then(tripRepository)
                 .should(times(1))
                 .deleteByMemberId(1L);
+        then(pointRepository)
+                .should(times(1))
+                .deleteByTripIds(tripIds);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/domain/PointRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/domain/PointRepositoryTest.java
@@ -4,6 +4,7 @@ import static dev.tripdraw.common.auth.OauthType.KAKAO;
 import static dev.tripdraw.trip.exception.TripExceptionType.POINT_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
 import dev.tripdraw.common.config.JpaConfig;
@@ -12,6 +13,7 @@ import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.trip.exception.TripException;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -37,19 +39,22 @@ class PointRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    private Trip trip;
+    private Trip huchuTrip;
+    private Trip herbTrip;
 
     @BeforeEach
     void setUp() {
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        trip = tripRepository.save(Trip.from(member));
+        Member huchu = memberRepository.save(new Member("후추", "kakaoId", KAKAO));
+        Member herb = memberRepository.save(new Member("허브", "kakaoId", KAKAO));
+        huchuTrip = tripRepository.save(Trip.from(huchu));
+        herbTrip = tripRepository.save(Trip.from(herb));
     }
 
     @Test
     void 위치정보_ID로_위치정보를_조회한다() {
         // given
         Point point = new Point(3.14, 5.25, LocalDateTime.now());
-        point.setTrip(trip);
+        point.setTrip(huchuTrip);
         pointRepository.save(point);
 
         // when
@@ -68,5 +73,37 @@ class PointRepositoryTest {
         assertThatThrownBy(() -> pointRepository.getById(wrongId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_NOT_FOUND.message());
+    }
+
+    @Test
+    void 여행_ID_목록으로_위치정보를_삭제한다() {
+        // given
+        Point huchuFirstPoint = new Point(3.14, 5.25, LocalDateTime.now());
+        huchuFirstPoint.setTrip(huchuTrip);
+        Point huchuSecondPoint = new Point(3.14, 5.25, LocalDateTime.now());
+        huchuSecondPoint.setTrip(huchuTrip);
+
+        Point herbFirstPoint = new Point(3.14, 5.25, LocalDateTime.now());
+        herbFirstPoint.setTrip(herbTrip);
+        Point herbSecondPoint = new Point(3.14, 5.25, LocalDateTime.now());
+        herbSecondPoint.setTrip(herbTrip);
+
+        pointRepository.save(huchuFirstPoint);
+        pointRepository.save(huchuSecondPoint);
+        pointRepository.save(herbFirstPoint);
+        pointRepository.save(herbSecondPoint);
+
+        List<Long> tripIds = List.of(huchuTrip.id(), herbTrip.id());
+
+        // when
+        pointRepository.deleteByTripIds(tripIds);
+        
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(pointRepository.existsById(huchuFirstPoint.id())).isFalse();
+            softly.assertThat(pointRepository.existsById(huchuSecondPoint.id())).isFalse();
+            softly.assertThat(pointRepository.existsById(herbFirstPoint.id())).isFalse();
+            softly.assertThat(pointRepository.existsById(herbSecondPoint.id())).isFalse();
+        });
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/domain/TripRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/domain/TripRepositoryTest.java
@@ -99,7 +99,7 @@ class TripRepositoryTest {
         tripRepository.deleteByMemberId(member.id());
 
         // then
-        assertThat(tripRepository.findById(trip.id())).isEmpty();
+        assertThat(tripRepository.existsById(trip.id())).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/trip/domain/TripRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/domain/TripRepositoryTest.java
@@ -14,6 +14,7 @@ import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.trip.exception.TripException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -122,5 +123,19 @@ class TripRepositoryTest {
         assertThatThrownBy(() -> tripRepository.getById(wrongId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.message());
+    }
+
+    @Test
+    void 회원_ID를_갖는_모든_여행_ID를_조회한다() {
+        // given
+        List<Long> tripIds = IntStream.range(0, 5)
+                .mapToObj(value -> tripRepository.save(Trip.from(member)).id())
+                .toList();
+
+        // when
+        List<Long> foundIds = tripRepository.findAllTripIdsByMemberId(member.id());
+
+        // then
+        assertThat(foundIds).isEqualTo(tripIds);
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #398 

### 📁 작업 설명

- 회원 삭제 시 쿼리가 19000 여개 나가는 것을 보고 깜짝 놀래서 바꿔보았습니다.

관련 문서 : https://github.com/woowacourse-teams/2023-trip-draw/discussions/402