### PR TITLE
[refactor] Test Fixture 적용 (#416)

### DIFF
--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthExtractorTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthExtractorTest.java
@@ -6,8 +6,8 @@ import static dev.tripdraw.test.fixture.AuthFixture.테스트_ACCESS_TOKEN_설�
 import static dev.tripdraw.test.fixture.AuthFixture.테스트_REFRESH_TOKEN_설정;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import dev.tripdraw.auth.exception.AuthException;
@@ -34,7 +34,7 @@ class AuthExtractorTest {
         String accessToken = jwtTokenProvider.generateAccessToken("1");
         HttpServletRequest request = mock(HttpServletRequest.class);
         String encoded = "Bearer " + accessToken;
-        when(request.getHeader(AUTHORIZATION)).thenReturn(encoded);
+        given(request.getHeader(AUTHORIZATION)).willReturn(encoded);
 
         // when
         LoginUser loginUser = authExtractor.extract(request);
@@ -48,7 +48,7 @@ class AuthExtractorTest {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         String encoded = "Basic aGVsbG86d29ybGQ=";
-        when(request.getHeader(AUTHORIZATION)).thenReturn(encoded);
+        given(request.getHeader(AUTHORIZATION)).willReturn(encoded);
 
         // expect
         assertThatThrownBy(() -> authExtractor.extract(request))
@@ -60,7 +60,7 @@ class AuthExtractorTest {
     void 요청_헤더에_인증_정보가_없을_경우_예외를_발생시킨다() {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getHeader(AUTHORIZATION)).thenReturn(null);
+        given(request.getHeader(AUTHORIZATION)).willReturn(null);
 
         // expect
         assertThatThrownBy(() -> authExtractor.extract(request))
@@ -73,7 +73,7 @@ class AuthExtractorTest {
         // given
         HttpServletRequest request = mock(HttpServletRequest.class);
         String notEncoded = "Bearer wrong.long.token";
-        when(request.getHeader(AUTHORIZATION)).thenReturn(notEncoded);
+        given(request.getHeader(AUTHORIZATION)).willReturn(notEncoded);
 
         // expect
         Assertions.assertThatThrownBy(() -> authExtractor.extract(request))

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
@@ -1,6 +1,8 @@
 package dev.tripdraw.auth.application;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.OAUTH_아이디;
+import static dev.tripdraw.test.fixture.MemberFixture.닉네임이_없는_사용자;
 import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
@@ -54,7 +56,7 @@ class AuthFacadeServiceTest {
     void 가입된_회원이_카카오_소셜_로그인하면_토큰이_포함된_응답을_반환한다() {
         // given
         memberRepository.save(사용자());
-        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+        OauthRequest oauthRequest = new OauthRequest(KAKAO, OAUTH_아이디);
 
         // when
         OauthResponse response = authFacadeService.login(oauthRequest);
@@ -69,7 +71,7 @@ class AuthFacadeServiceTest {
     @Test
     void 신규_회원이_로그인하면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
         // given
-        OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+        OauthRequest oauthRequest = new OauthRequest(KAKAO, OAUTH_아이디);
 
         // when
         OauthResponse response = authFacadeService.login(oauthRequest);
@@ -84,8 +86,8 @@ class AuthFacadeServiceTest {
     @Test
     void 신규_회원의_닉네임을_등록하면_토큰이_포함된_응답을_반환한다() {
         // given
-        memberRepository.save(사용자());
-        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
+        memberRepository.save(닉네임이_없는_사용자());
+        RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, OAUTH_아이디);
 
         // when
         OauthResponse response = authFacadeService.register(registerRequest);

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthFacadeServiceTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.auth.application;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 
@@ -52,7 +53,7 @@ class AuthFacadeServiceTest {
     @Test
     void 가입된_회원이_카카오_소셜_로그인하면_토큰이_포함된_응답을_반환한다() {
         // given
-        memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        memberRepository.save(사용자());
         OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
 
         // when
@@ -83,9 +84,7 @@ class AuthFacadeServiceTest {
     @Test
     void 신규_회원의_닉네임을_등록하면_토큰이_포함된_응답을_반환한다() {
         // given
-        Member member = Member.of("kakaoId", KAKAO);
-        memberRepository.save(member);
-
+        memberRepository.save(사용자());
         RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
 
         // when
@@ -101,7 +100,7 @@ class AuthFacadeServiceTest {
     @Test
     void Refresh_토큰을_입력받아_Access_토큰과_Refresh_토큰을_재발급한다() {
         // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        Member member = memberRepository.save(사용자());
         String refreshToken = jwtTokenProvider.generateRefreshToken();
         refreshTokenRepository.save(new RefreshToken(member.id(), refreshToken));
         TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest(refreshToken);

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
@@ -1,8 +1,8 @@
 package dev.tripdraw.auth.application;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
 import static dev.tripdraw.member.exception.MemberExceptionType.DUPLICATE_NICKNAME;
 import static dev.tripdraw.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.test.fixture.AuthFixture.OAuth_정보;
 import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,7 +12,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import dev.tripdraw.auth.dto.OauthInfo;
 import dev.tripdraw.common.auth.OauthType;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
@@ -37,8 +36,6 @@ class AuthServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
-    private final OauthInfo oauthInfo = new OauthInfo("id", KAKAO);
-
     @Test
     void 신규_회원이_로그인하면_회원을_저장_후_빈_회원을_반환한다() {
         // given
@@ -46,7 +43,7 @@ class AuthServiceTest {
                 .willReturn(Optional.empty());
 
         // when
-        Optional<Member> member = authService.login(oauthInfo);
+        Optional<Member> member = authService.login(OAuth_정보());
 
         // then
         assertSoftly(softly -> {
@@ -58,12 +55,11 @@ class AuthServiceTest {
     @Test
     void 기존의_회원이_로그인하면_회원_정보를_반환한다() {
         // given
-        Member 사용자 = 사용자();
         given(memberRepository.findByOauthIdAndOauthType(any(String.class), any(OauthType.class)))
-                .willReturn(Optional.of(사용자));
+                .willReturn(Optional.of(사용자()));
 
         // when
-        Optional<Member> member = authService.login(oauthInfo);
+        Optional<Member> member = authService.login(OAuth_정보());
 
         // then
         assertThat(member).isPresent();
@@ -76,7 +72,7 @@ class AuthServiceTest {
                 .willReturn(Optional.of(사용자()));
 
         // when
-        Optional<Member> member = authService.register(oauthInfo, "통후추");
+        Optional<Member> member = authService.register(OAuth_정보(), "통후추");
 
         // then
         assertThat(member).isPresent();
@@ -89,7 +85,7 @@ class AuthServiceTest {
                 .willReturn(Optional.empty());
 
         // expect
-        assertThatThrownBy(() -> authService.register(oauthInfo, "통후추"))
+        assertThatThrownBy(() -> authService.register(OAuth_정보(), "통후추"))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(MEMBER_NOT_FOUND.message());
     }
@@ -101,7 +97,7 @@ class AuthServiceTest {
                 .willReturn(true);
 
         // expect
-        assertThatThrownBy(() -> authService.register(oauthInfo, "통후추"))
+        assertThatThrownBy(() -> authService.register(OAuth_정보(), "통후추"))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(DUPLICATE_NICKNAME.message());
     }

--- a/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/AuthServiceTest.java
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
 
 import dev.tripdraw.common.auth.OauthType;
 import dev.tripdraw.member.domain.Member;

--- a/backend/src/test/java/dev/tripdraw/auth/application/OAuthServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/OAuthServiceTest.java
@@ -1,8 +1,10 @@
 package dev.tripdraw.auth.application;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.AuthFixture.OAUTH_TOKEN;
+import static dev.tripdraw.test.fixture.MemberFixture.OAUTH_아이디;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import dev.tripdraw.auth.dto.OauthInfo;
 import dev.tripdraw.auth.oauth.OauthClientProvider;
@@ -29,20 +31,16 @@ class OAuthServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(oauthClientProvider.provide(KAKAO)).thenReturn(new TestKakaoApiClient());
+        given(oauthClientProvider.provide(KAKAO)).willReturn(new TestKakaoApiClient());
     }
 
     @Test
     void Oauth_공통_정보를_반환한다() {
-        // given
-        String oauthToken = "oauth.kakao.token";
+        // expect
+        OauthInfo oauthInfo = oAuthService.request(KAKAO, OAUTH_TOKEN);
 
-        // when
-        OauthInfo oauthInfo = oAuthService.request(KAKAO, oauthToken);
-
-        // then
         assertSoftly(softly -> {
-            softly.assertThat(oauthInfo.oauthId()).isEqualTo("kakaoId");
+            softly.assertThat(oauthInfo.oauthId()).isEqualTo(OAUTH_아이디);
             softly.assertThat(oauthInfo.oauthType()).isEqualTo(KAKAO);
         });
     }

--- a/backend/src/test/java/dev/tripdraw/auth/application/TokenGenerateServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/application/TokenGenerateServiceTest.java
@@ -8,8 +8,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
 
 import dev.tripdraw.auth.domain.RefreshToken;
 import dev.tripdraw.auth.domain.RefreshTokenRepository;

--- a/backend/src/test/java/dev/tripdraw/auth/domain/RefreshTokenRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/domain/RefreshTokenRepositoryTest.java
@@ -27,7 +27,7 @@ class RefreshTokenRepositoryTest {
     @Test
     void 토큰을_입력받아_refreshToken_객체를_반환한다() {
         // given
-        long memberId = 1L;
+        Long memberId = 1L;
         RefreshToken refreshToken = new RefreshToken(memberId, "refreshToken");
         refreshTokenRepository.save(refreshToken);
 
@@ -41,7 +41,7 @@ class RefreshTokenRepositoryTest {
     @Test
     void 사용자_아이디를_입력받아_해당되는_모든_RefreshToken을_제거한다() {
         // given
-        long memberId = 1L;
+        Long memberId = 1L;
         refreshTokenRepository.save(new RefreshToken(memberId, "refreshToken"));
         refreshTokenRepository.save(new RefreshToken(memberId, "refreshToken"));
 

--- a/backend/src/test/java/dev/tripdraw/auth/dto/KakaoInfoResponseTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/dto/KakaoInfoResponseTest.java
@@ -1,9 +1,9 @@
 package dev.tripdraw.auth.dto;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class KakaoInfoResponseTest {
@@ -11,12 +11,7 @@ class KakaoInfoResponseTest {
     @Test
     void Oauth_공통_정보를_반환한다() {
         // given
-        KakaoInfoResponse kakaoInfoResponse = new KakaoInfoResponse(
-                "kakaoId",
-                true,
-                LocalDateTime.now(),
-                null
-        );
+        KakaoInfoResponse kakaoInfoResponse = new KakaoInfoResponse("kakaoId", true, now(), null);
 
         // when
         OauthInfo oauthInfo = kakaoInfoResponse.toOauthInfo();

--- a/backend/src/test/java/dev/tripdraw/auth/oauth/KakaoApiClientTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/oauth/KakaoApiClientTest.java
@@ -1,15 +1,15 @@
 package dev.tripdraw.auth.oauth;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import dev.tripdraw.auth.dto.KakaoInfoResponse;
 import dev.tripdraw.auth.dto.OauthInfo;
 import dev.tripdraw.common.auth.OauthType;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -45,14 +45,8 @@ class KakaoApiClientTest {
         // given
         String accessToken = "good.access.token";
         KakaoApiClient kakaoApiClient = new KakaoApiClient("url", restTemplate);
-
-        when(restTemplate.postForObject(any(String.class), any(Object.class), any()))
-                .thenReturn(new KakaoInfoResponse(
-                        "kakaoId",
-                        true,
-                        LocalDateTime.now(),
-                        null
-                ));
+        KakaoInfoResponse kakaoInfoResponse = new KakaoInfoResponse("kakaoId", true, now(), null);
+        given(restTemplate.postForObject(any(String.class), any(Object.class), any())).willReturn(kakaoInfoResponse);
 
         // when
         OauthInfo oauthInfo = kakaoApiClient.requestOauthInfo(accessToken);

--- a/backend/src/test/java/dev/tripdraw/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/auth/presentation/AuthControllerTest.java
@@ -1,10 +1,13 @@
 package dev.tripdraw.auth.presentation;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.AuthFixture.OAUTH_TOKEN;
 import static dev.tripdraw.test.fixture.AuthFixture.만료된_토큰_생성용_ACCESS_TOKEN_설정;
 import static dev.tripdraw.test.fixture.AuthFixture.만료된_토큰_생성용_REFRESH_TOKEN_설정;
+import static dev.tripdraw.test.fixture.MemberFixture.닉네임이_없는_사용자;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -58,8 +61,7 @@ class AuthControllerTest extends ControllerTest {
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
-        when(oauthClientProvider.provide(KAKAO))
-                .thenReturn(new TestKakaoApiClient());
+        given(oauthClientProvider.provide(KAKAO)).willReturn(new TestKakaoApiClient());
     }
 
     @Nested
@@ -68,8 +70,8 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 가입된_회원이면_토큰이_포함된_응답을_반환한다() {
             // given
-            memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-            OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+            memberRepository.save(사용자());
+            OauthRequest oauthRequest = new OauthRequest(KAKAO, OAUTH_TOKEN);
 
             // when
             ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -92,7 +94,7 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 신규_회원이면_회원을_저장하고_빈_토큰이_포함된_응답을_반환한다() {
             // given
-            OauthRequest oauthRequest = new OauthRequest(KAKAO, "oauth.kakao.token");
+            OauthRequest oauthRequest = new OauthRequest(KAKAO, OAUTH_TOKEN);
 
             // when
             ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -119,10 +121,8 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 정상_등록하면_토큰이_포함된_응답을_반환한다() {
             // given
-            Member member = Member.of("kakaoId", KAKAO);
-            memberRepository.save(member);
-
-            RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, "oauth.kakao.token");
+            memberRepository.save(닉네임이_없는_사용자());
+            RegisterRequest registerRequest = new RegisterRequest("통후추", KAKAO, OAUTH_TOKEN);
 
             // when
             ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -145,7 +145,7 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 회원이_존재하지_않으면_예외가_발생한다() {
             // given
-            RegisterRequest registerRequest = new RegisterRequest("저장안된후추", KAKAO, "oauth.kakao.token");
+            RegisterRequest registerRequest = new RegisterRequest("저장안된후추", KAKAO, OAUTH_TOKEN);
 
             // expect
             RestAssured.given().log().all()
@@ -159,8 +159,8 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 이미_존재하는_닉네임이면_예외가_발생한다() {
             // given
-            Member member = memberRepository.save(new Member("중복닉네임", "kakaoId", KAKAO));
-            RegisterRequest registerRequest = new RegisterRequest(member.nickname(), KAKAO, "oauth.kakao.token");
+            Member member = memberRepository.save(사용자());
+            RegisterRequest registerRequest = new RegisterRequest(member.nickname(), KAKAO, OAUTH_TOKEN);
 
             // expect
             RestAssured.given().log().all()
@@ -192,7 +192,7 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 만료기간이_남은_Refresh_토큰이면_Access_토큰과_Refresh_토큰을_재발급한다() {
             // given
-            Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+            Member member = memberRepository.save(사용자());
             String refreshToken = jwtTokenProvider.generateRefreshToken();
             refreshTokenRepository.save(new RefreshToken(member.id(), refreshToken));
             TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest(refreshToken);
@@ -218,7 +218,7 @@ class AuthControllerTest extends ControllerTest {
         @Test
         void 만료기간이_지난_Refresh_토큰이면_401_예외가_발생한다() {
             // given
-            Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+            Member member = memberRepository.save(사용자());
             JwtTokenProvider expiredTokenProvider = new JwtTokenProvider(
                     만료된_토큰_생성용_ACCESS_TOKEN_설정(),
                     만료된_토큰_생성용_REFRESH_TOKEN_설정()

--- a/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerIntegrationTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerIntegrationTest.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.draw.application;
 
-import static dev.tripdraw.test.fixture.TestFixture.감상;
-import static dev.tripdraw.test.fixture.TestFixture.여행;
+import static dev.tripdraw.test.fixture.PostFixture.감상;
+import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerIntegrationTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerIntegrationTest.java
@@ -5,7 +5,7 @@ import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.timeout;
+import static org.mockito.BDDMockito.timeout;
 
 import dev.tripdraw.post.domain.PostCreateEvent;
 import dev.tripdraw.post.domain.PostRepository;
@@ -43,10 +43,8 @@ class PostCreateEventHandlerIntegrationTest {
     void 감상생성_이벤트를_발생시키면_이미지를_생성_요청을_한다() {
         // given
         PostCreateEvent postCreateEvent = new PostCreateEvent(1L, 1L);
-        given(tripRepository.getTripWithPoints(postCreateEvent.tripId()))
-                .willReturn(여행());
-        given(postRepository.getByPostId(postCreateEvent.postId()))
-                .willReturn(감상());
+        given(tripRepository.getTripWithPoints(postCreateEvent.tripId())).willReturn(여행());
+        given(postRepository.getByPostId(postCreateEvent.postId())).willReturn(감상());
 
         // when
         transactionTemplate.executeWithoutResult(action -> applicationEventPublisher.publishEvent(postCreateEvent));

--- a/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerTest.java
@@ -5,7 +5,7 @@ import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.times;
 
 import dev.tripdraw.post.domain.PostCreateEvent;
 import dev.tripdraw.post.domain.PostRepository;
@@ -39,10 +39,8 @@ class PostCreateEventHandlerTest {
     void 감상생성_이벤트를_받아_이미지를_생성_요청을_한다() {
         // given
         PostCreateEvent postCreateEvent = new PostCreateEvent(1L, 1L);
-        given(tripRepository.getTripWithPoints(postCreateEvent.tripId()))
-                .willReturn(여행());
-        given(postRepository.getByPostId(postCreateEvent.postId()))
-                .willReturn(감상());
+        given(tripRepository.getTripWithPoints(postCreateEvent.tripId())).willReturn(여행());
+        given(postRepository.getByPostId(postCreateEvent.postId())).willReturn(감상());
 
         // when
         postCreateEventHandler.handle(postCreateEvent);

--- a/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/PostCreateEventHandlerTest.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.draw.application;
 
-import static dev.tripdraw.test.fixture.TestFixture.감상;
-import static dev.tripdraw.test.fixture.TestFixture.여행;
+import static dev.tripdraw.test.fixture.PostFixture.감상;
+import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/backend/src/test/java/dev/tripdraw/draw/application/RouteImageGeneratorTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/RouteImageGeneratorTest.java
@@ -5,8 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import dev.tripdraw.draw.application.RouteImageGenerator;
-import dev.tripdraw.draw.application.RouteImageUploader;
 import java.awt.image.BufferedImage;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;

--- a/backend/src/test/java/dev/tripdraw/draw/application/RouteImageUploaderTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/RouteImageUploaderTest.java
@@ -4,15 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
-import dev.tripdraw.draw.application.RouteImageUploader;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import javax.imageio.ImageIO;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -28,9 +27,8 @@ class RouteImageUploaderTest {
         RouteImageUploader routeImageUploader = new RouteImageUploader(domain, base, route);
 
         // expect
-        try (MockedStatic<ImageIO> imageIO = Mockito.mockStatic(ImageIO.class)) {
-            String imageUrl = routeImageUploader.upload(bufferedImage);
-
+        try (MockedStatic<ImageIO> imageIO = BDDMockito.mockStatic(ImageIO.class)) {
+            routeImageUploader.upload(bufferedImage);
             imageIO.verify(
                     () -> ImageIO.write(any(BufferedImage.class), any(String.class), any(File.class)),
                     times(1)
@@ -48,9 +46,8 @@ class RouteImageUploaderTest {
         RouteImageUploader routeImageUploader = new RouteImageUploader(domain, base, route);
 
         // expect
-        try (MockedStatic<ImageIO> imageIO = Mockito.mockStatic(ImageIO.class)) {
+        try (MockedStatic<ImageIO> imageIO = BDDMockito.mockStatic(ImageIO.class)) {
             String imageUrl = routeImageUploader.upload(bufferedImage);
-
             assertThat(imageUrl).startsWith(domain + route);
         }
     }

--- a/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerIntegrationTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerIntegrationTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.draw.application;
 
-import static dev.tripdraw.test.fixture.TestFixture.여행;
+import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerIntegrationTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerIntegrationTest.java
@@ -4,7 +4,7 @@ import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.timeout;
+import static org.mockito.BDDMockito.timeout;
 
 import dev.tripdraw.trip.domain.TripRepository;
 import dev.tripdraw.trip.domain.TripUpdateEvent;

--- a/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerTest.java
@@ -4,7 +4,7 @@ import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.times;
 
 import dev.tripdraw.trip.domain.TripRepository;
 import dev.tripdraw.trip.domain.TripUpdateEvent;

--- a/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/application/TripUpdateEventHandlerTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.draw.application;
 
-import static dev.tripdraw.test.fixture.TestFixture.여행;
+import static dev.tripdraw.test.fixture.TripFixture.여행;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/backend/src/test/java/dev/tripdraw/draw/domain/CoordinatesTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/domain/CoordinatesTest.java
@@ -5,9 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.tripdraw.draw.domain.Coordinates;
-import dev.tripdraw.draw.domain.Position;
-import dev.tripdraw.draw.domain.Positions;
 import dev.tripdraw.draw.exception.DrawException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;

--- a/backend/src/test/java/dev/tripdraw/draw/domain/PositionsTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/domain/PositionsTest.java
@@ -2,8 +2,6 @@ package dev.tripdraw.draw.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dev.tripdraw.draw.domain.Position;
-import dev.tripdraw.draw.domain.Positions;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/backend/src/test/java/dev/tripdraw/draw/domain/RouteImageDrawerTest.java
+++ b/backend/src/test/java/dev/tripdraw/draw/domain/RouteImageDrawerTest.java
@@ -2,18 +2,16 @@ package dev.tripdraw.draw.domain;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
 
-import dev.tripdraw.draw.domain.Position;
-import dev.tripdraw.draw.domain.Positions;
-import dev.tripdraw.draw.domain.RouteImageDrawer;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.Line2D;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class RouteImageDrawerTest {
 
@@ -40,7 +38,7 @@ public class RouteImageDrawerTest {
     @Test
     void 위치_목록을_입력받아_이미지에_경로를_그린다() {
         // given
-        Graphics2D graphics2D = Mockito.mock(Graphics2D.class);
+        Graphics2D graphics2D = mock(Graphics2D.class);
         RouteImageDrawer routeImageDrawer = new RouteImageDrawer(null, graphics2D);
         Positions positions = new Positions(List.of(
                 new Position(254, 100), new Position(302, 150), new Position(389, 138), new Position(482, 164),
@@ -51,13 +49,13 @@ public class RouteImageDrawerTest {
         routeImageDrawer.drawLine(positions);
 
         // then
-        Mockito.verify(graphics2D, times(positions.size() - 1)).draw(any(Line2D.Double.class));
+        verify(graphics2D, times(positions.size() - 1)).draw(any(Line2D.Double.class));
     }
 
     @Test
     void 위치_목록을_입력받아_이미지에_위치_점을_그린다() {
         // given
-        Graphics2D graphics2D = Mockito.mock(Graphics2D.class);
+        Graphics2D graphics2D = mock(Graphics2D.class);
         RouteImageDrawer routeImageDrawer = new RouteImageDrawer(null, graphics2D);
         Positions positions = new Positions(List.of(
                 new Position(254, 100), new Position(302, 150), new Position(389, 138)
@@ -67,19 +65,19 @@ public class RouteImageDrawerTest {
         routeImageDrawer.drawPoint(positions);
 
         // then
-        Mockito.verify(graphics2D, times(positions.size())).draw(any(Line2D.Double.class));
+        verify(graphics2D, times(positions.size())).draw(any(Line2D.Double.class));
     }
 
     @Test
     void 자원할당을_해제한다() {
         // given
-        Graphics2D graphics2D = Mockito.mock(Graphics2D.class);
+        Graphics2D graphics2D = mock(Graphics2D.class);
         RouteImageDrawer routeImageDrawer = new RouteImageDrawer(null, graphics2D);
 
         // when
         routeImageDrawer.dispose();
 
         // then
-        Mockito.verify(graphics2D, times(1)).dispose();
+        verify(graphics2D, times(1)).dispose();
     }
 }

--- a/backend/src/test/java/dev/tripdraw/file/application/FileUploaderTest.java
+++ b/backend/src/test/java/dev/tripdraw/file/application/FileUploaderTest.java
@@ -4,10 +4,12 @@ import static dev.tripdraw.file.domain.FileType.IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
 
 import dev.tripdraw.file.exception.FileIOException;
 import java.io.File;
@@ -19,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -43,9 +44,9 @@ class FileUploaderTest {
         UUID randomUUID = UUID.randomUUID();
         String baseUrl = "https://example.com/files/";
         String expectedFileUrl = baseUrl + randomUUID + ".jpg";
-        MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
-        when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());
-        when(fileUrlMaker.make(any())).thenReturn(expectedFileUrl);
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        given(multipartFile.getContentType()).willReturn(IMAGE.contentType());
+        given(fileUrlMaker.make(any())).willReturn(expectedFileUrl);
 
         // when
         String url = fileUploader.upload(multipartFile);
@@ -57,8 +58,8 @@ class FileUploaderTest {
     @Test
     void 파일을_업로드_한다() throws IOException {
         // given
-        MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
-        when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        given(multipartFile.getContentType()).willReturn(IMAGE.contentType());
 
         // when
         fileUploader.upload(multipartFile);
@@ -70,7 +71,7 @@ class FileUploaderTest {
     @Test
     void 파일_저장에_실패할시_예외를_발생시킨다() throws IOException {
         // given
-        MultipartFile multipartFile = Mockito.mock(MultipartFile.class);
+        MultipartFile multipartFile = mock(MultipartFile.class);
         when(multipartFile.getContentType()).thenReturn(IMAGE.contentType());
         doThrow(new IOException()).when(multipartFile).transferTo(any(File.class));
 

--- a/backend/src/test/java/dev/tripdraw/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/member/application/MemberServiceTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.member.application;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -9,14 +9,7 @@ import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberDeleteEvent;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.member.dto.MemberSearchResponse;
-import dev.tripdraw.post.domain.Post;
-import dev.tripdraw.post.domain.PostRepository;
 import dev.tripdraw.test.ServiceTest;
-import dev.tripdraw.trip.domain.Point;
-import dev.tripdraw.trip.domain.Trip;
-import dev.tripdraw.trip.domain.TripName;
-import dev.tripdraw.trip.domain.TripRepository;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,29 +29,11 @@ class MemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @Autowired
-    private TripRepository tripRepository;
-
-    @Autowired
-    private PostRepository postRepository;
-
     private Member member;
-    private Trip trip;
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        trip = tripRepository.save(new Trip(TripName.from("통후추의 여행"), member.id()));
-        Point point = new Point(3.14, 5.25, LocalDateTime.now());
-        point.setTrip(trip);
-        postRepository.save(new Post(
-                "제목",
-                point,
-                "위치",
-                "오늘은 날씨가 좋네요.",
-                member.id(),
-                trip.id()
-        ));
+        member = memberRepository.save(사용자());
     }
 
     @Test
@@ -69,7 +44,7 @@ class MemberServiceTest {
         // when
         MemberSearchResponse response = memberService.find(loginUser);
 
-        // expect
+        // then
         assertThat(response).usingRecursiveComparison().isEqualTo(
                 new MemberSearchResponse(member.id(), "통후추")
         );

--- a/backend/src/test/java/dev/tripdraw/member/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/member/domain/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package dev.tripdraw.member.domain;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
 import static dev.tripdraw.member.exception.MemberExceptionType.MEMBER_NOT_FOUND;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
@@ -31,20 +32,20 @@ class MemberRepositoryTest {
     @Test
     void Oauth_ID와_종류로_회원을_조회한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
+        Member member = 사용자();
         memberRepository.save(member);
 
         // when
-        Member foundMember = memberRepository.findByOauthIdAndOauthType("kakaoId", KAKAO).get();
+        Member foundMember = memberRepository.findByOauthIdAndOauthType(member.oauthId(), KAKAO).get();
 
         // then
-        assertThat(foundMember.nickname()).isEqualTo("통후추");
+        assertThat(foundMember.nickname()).isEqualTo(member.nickname());
     }
 
     @Test
     void Oauth_ID와_종류로_회원을_조회할_때_존재하지_않으면_빈_Optional을_반환한다() {
         // given
-        Optional<Member> foundMember = memberRepository.findByOauthIdAndOauthType("wrongKakaoId", KAKAO);
+        Optional<Member> foundMember = memberRepository.findByOauthIdAndOauthType("", KAKAO);
 
         // expect
         assertThat(foundMember).isEmpty();
@@ -53,7 +54,7 @@ class MemberRepositoryTest {
     @Test
     void 회원_ID로_회원을_조회한다() {
         // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        Member member = memberRepository.save(사용자());
 
         // when
         Member foundMember = memberRepository.getById(member.id());
@@ -76,12 +77,12 @@ class MemberRepositoryTest {
     @Test
     void 회원_ID로_회원_닉네임을_얻는다() {
         // given
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        Member member = memberRepository.save(사용자());
 
         // when
         String nickname = memberRepository.getNicknameById(member.id());
 
         // then
-        assertThat(nickname).isEqualTo("통후추");
+        assertThat(nickname).isEqualTo(member.nickname());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/post/application/PostDeleteEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostDeleteEventHandlerTest.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.post.application;
 
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.times;
 
 import dev.tripdraw.member.domain.MemberDeleteEvent;
 import dev.tripdraw.post.domain.PostRepository;

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.post.application;
 
-import static dev.tripdraw.post.application.PostServiceTest.PostDtoFixture.감상_생성_요청;
-import static dev.tripdraw.post.application.PostServiceTest.PostDtoFixture.현재_위치_감상_생성_요청;
+import static dev.tripdraw.post.application.PostServiceTest.PostRequestFixture.감상_생성_요청;
+import static dev.tripdraw.post.application.PostServiceTest.PostRequestFixture.현재_위치_감상_생성_요청;
 import static dev.tripdraw.post.exception.PostExceptionType.NOT_AUTHORIZED_TO_POST;
 import static dev.tripdraw.post.exception.PostExceptionType.POST_NOT_FOUND;
 import static dev.tripdraw.test.fixture.MemberFixture.다른_사용자;
@@ -385,7 +385,7 @@ class PostServiceTest {
         assertThat(trip.imageUrl()).isEqualTo("hello.png");
     }
 
-    static class PostDtoFixture {
+    static class PostRequestFixture {
         public static PostAndPointCreateRequest 현재_위치_감상_생성_요청(Long tripId) {
             return new PostAndPointCreateRequest(
                     tripId,

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -1,24 +1,30 @@
 package dev.tripdraw.post.application;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.post.application.PostServiceTest.PostDtoFixture.감상_생성_요청;
+import static dev.tripdraw.post.application.PostServiceTest.PostDtoFixture.현재_위치_감상_생성_요청;
 import static dev.tripdraw.post.exception.PostExceptionType.NOT_AUTHORIZED_TO_POST;
 import static dev.tripdraw.post.exception.PostExceptionType.POST_NOT_FOUND;
+import static dev.tripdraw.test.fixture.MemberFixture.다른_사용자;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
+import static dev.tripdraw.test.fixture.PostFixture.새로운_감상;
 import static dev.tripdraw.trip.exception.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.trip.exception.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.mock;
 
 import dev.tripdraw.common.auth.LoginUser;
 import dev.tripdraw.draw.application.RouteImageGenerator;
 import dev.tripdraw.file.application.FileUploader;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
+import dev.tripdraw.post.domain.Post;
+import dev.tripdraw.post.domain.PostRepository;
 import dev.tripdraw.post.dto.PostAndPointCreateRequest;
 import dev.tripdraw.post.dto.PostCreateResponse;
 import dev.tripdraw.post.dto.PostRequest;
@@ -36,7 +42,6 @@ import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
 import dev.tripdraw.trip.exception.TripException;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -55,6 +60,9 @@ class PostServiceTest {
     private PostService postService;
 
     @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
     private TripRepository tripRepository;
 
     @Autowired
@@ -69,35 +77,22 @@ class PostServiceTest {
     @MockBean
     private FileUploader fileUploader;
 
+    private Member member;
     private Trip trip;
-    private LoginUser loginUser;
-    private LoginUser otherUser;
     private Point point;
 
     @BeforeEach
     void setUp() {
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        Member otherMember = memberRepository.save(new Member("순후추", "kakaoId", KAKAO));
+        member = memberRepository.save(사용자());
         trip = tripRepository.save(Trip.of(member.id(), member.nickname()));
-        point = new Point(1.1, 2.1, LocalDateTime.now());
-        point.setTrip(trip);
-        pointRepository.save(point);
-        loginUser = new LoginUser(member.id());
-        otherUser = new LoginUser(otherMember.id());
+        point = pointRepository.save(새로운_위치정보(trip));
     }
 
     @Test
     void 현재_위치에_대한_감상을_생성한다() {
         // given
-        PostAndPointCreateRequest request = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(trip.id());
 
         // when
         PostCreateResponse postCreateResponse = postService.addAtCurrentPoint(loginUser, request, null);
@@ -109,19 +104,11 @@ class PostServiceTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        LoginUser wrongUser = new LoginUser(Long.MIN_VALUE);
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        LoginUser invalidUser = new LoginUser(Long.MIN_VALUE);
+        PostAndPointCreateRequest postAndPointCreateRequest = 현재_위치_감상_생성_요청(trip.id());
 
         // expect
-        assertThatThrownBy(() -> postService.addAtCurrentPoint(wrongUser, postAndPointCreateRequest, null))
+        assertThatThrownBy(() -> postService.addAtCurrentPoint(invalidUser, postAndPointCreateRequest, null))
                 .isInstanceOf(TripException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_TRIP.message());
     }
@@ -129,18 +116,11 @@ class PostServiceTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
-        PostAndPointCreateRequest requestOfNotExistedTripId = new PostAndPointCreateRequest(
-                Long.MIN_VALUE,
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostAndPointCreateRequest postAndPointCreateRequest = 현재_위치_감상_생성_요청(Long.MIN_VALUE);
 
         // expect
-        assertThatThrownBy(() -> postService.addAtCurrentPoint(loginUser, requestOfNotExistedTripId, null))
+        assertThatThrownBy(() -> postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, null))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.message());
     }
@@ -148,13 +128,8 @@ class PostServiceTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성한다() {
         // given
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                point.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostRequest postRequest = 감상_생성_요청(trip.id(), point.id());
         given(routeImageGenerator.generate(any(), any(), any(), any())).willReturn("hello.png");
 
         // when
@@ -167,17 +142,11 @@ class PostServiceTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        LoginUser wrongUser = new LoginUser(Long.MIN_VALUE);
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                point.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        PostRequest postRequest = 감상_생성_요청(trip.id(), point.id());
+        LoginUser invalidUser = new LoginUser(Long.MIN_VALUE);
 
         // expect
-        assertThatThrownBy(() -> postService.addAtExistingLocation(wrongUser, postRequest, null))
+        assertThatThrownBy(() -> postService.addAtExistingLocation(invalidUser, postRequest, null))
                 .isInstanceOf(TripException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_TRIP.message());
     }
@@ -185,16 +154,11 @@ class PostServiceTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
-        PostRequest requestOfNotExistedTripId = new PostRequest(
-                Long.MIN_VALUE,
-                point.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostRequest postRequest = 감상_생성_요청(Long.MIN_VALUE, point.id());
 
         // expect
-        assertThatThrownBy(() -> postService.addAtExistingLocation(loginUser, requestOfNotExistedTripId, null))
+        assertThatThrownBy(() -> postService.addAtExistingLocation(loginUser, postRequest, null))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.message());
     }
@@ -202,16 +166,11 @@ class PostServiceTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_위치의_ID이면_예외를_발생시킨다() {
         // given
-        PostRequest requestOfNotExistedPointId = new PostRequest(
-                trip.id(),
-                Long.MIN_VALUE,
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostRequest postRequest = 감상_생성_요청(trip.id(), Long.MIN_VALUE);
 
         // expect
-        assertThatThrownBy(() -> postService.addAtExistingLocation(loginUser, requestOfNotExistedPointId, null))
+        assertThatThrownBy(() -> postService.addAtExistingLocation(loginUser, postRequest, null))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_NOT_FOUND.message());
     }
@@ -219,17 +178,13 @@ class PostServiceTest {
     @Test
     void 특정_감상을_조회한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
+        Post post = postRepository.save(새로운_감상(point, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
 
         // when
-        PostResponse postResponse = postService.read(postCreateResponse.postId());
+        PostResponse postResponse = postService.read(post.id());
 
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(postResponse.postId()).isNotNull();
-            softly.assertThat(postResponse.title()).isEqualTo("우도의 바닷가");
-            softly.assertThat(postResponse.pointResponse().pointId()).isNotNull();
-        });
+        assertThat(postResponse).isEqualTo(PostResponse.from(post));
     }
 
     @Test
@@ -243,20 +198,17 @@ class PostServiceTest {
     @Test
     void 특정_여행의_모든_감상을_조회한다() {
         // given
-        createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
-        createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
+        Point point1 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 29));
+        Point point2 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 30));
+        Post post1 = postRepository.save(새로운_감상(point1, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
+        Post post2 = postRepository.save(새로운_감상(point2, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
 
         // when
         PostsResponse postsResponse = postService.readAllByTripId(trip.id());
 
         // then
-        List<PostResponse> posts = postsResponse.posts();
-        assertSoftly(softly -> {
-            softly.assertThat(posts.get(0).postId()).isNotNull();
-            softly.assertThat(posts.get(0).pointResponse().pointId()).isNotNull();
-            softly.assertThat(posts.get(1).postId()).isNotNull();
-            softly.assertThat(posts.get(1).pointResponse().pointId()).isNotNull();
-        });
+        assertThat(postsResponse.posts())
+                .containsExactly(PostResponse.from(post2), PostResponse.from(post1));
     }
 
     @Test
@@ -268,63 +220,74 @@ class PostServiceTest {
     }
 
     @Test
-    void 조건에_해당하는_모든_여행을_조회한다() {
+    void 주소로_모든_여행을_조회한다() {
         // given
-        PostCreateResponse jejuMay = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 5, 12, 15, 30));
-        PostCreateResponse jejuJuly = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 12, 15, 30));
-        PostCreateResponse seoulJuly = createPost("서울특별시 송파구 문정동", LocalDateTime.of(2023, 7, 12, 15, 30));
+        Point mayPoint = pointRepository.save(새로운_위치정보(2023, 5, 12, 15, 30));
+        Point julyPoint1 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 30));
+        Point julyPoint2 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 30));
+        Post jejuMayPost = postRepository.save(새로운_감상(mayPoint, member.id(), "제주특별자치도 제주시 애월읍"));
+        Post jejuJulyPost = postRepository.save(새로운_감상(julyPoint1, member.id(), "제주특별자치도 제주시 애월읍"));
+        Post seoulJulyPost = postRepository.save(새로운_감상(julyPoint2, member.id(), "서울특별시 송파구 문정동"));
 
-        PostSearchRequest postSearchRequestJeju = PostSearchRequest.builder()
+        PostSearchRequest postSearchRequest = PostSearchRequest.builder()
                 .address("제주특별자치도 제주시 애월읍")
                 .limit(10)
                 .build();
 
-        PostSearchRequest postSearchRequestJuly = PostSearchRequest.builder()
+        // when
+        PostsSearchResponse postsSearchResponse = postService.readAll(postSearchRequest);
+
+        // then
+        assertThat(postsSearchResponse.posts())
+                .contains(PostSearchResponse.from(jejuJulyPost), PostSearchResponse.from(jejuMayPost));
+    }
+
+    @Test
+    void 기간으로_진행된_여행을_조회한다() {
+        // given
+        Point mayPoint = pointRepository.save(새로운_위치정보(2023, 5, 12, 15, 30));
+        Point julyPoint1 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 30));
+        Point julyPoint2 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 30));
+        Post jejuMayPost = postRepository.save(새로운_감상(mayPoint, member.id(), "제주특별자치도 제주시 애월읍"));
+        Post jejuJulyPost = postRepository.save(새로운_감상(julyPoint1, member.id(), "제주특별자치도 제주시 애월읍"));
+        Post seoulJulyPost = postRepository.save(새로운_감상(julyPoint2, member.id(), "서울특별시 송파구 문정동"));
+
+        PostSearchRequest postSearchRequest = PostSearchRequest.builder()
                 .months(Set.of(7))
                 .limit(10)
                 .build();
 
         // when
-        PostsSearchResponse postsSearchJejuResponse = postService.readAll(postSearchRequestJeju);
-        PostsSearchResponse postsSearchJulyResponse = postService.readAll(postSearchRequestJuly);
+        PostsSearchResponse postsSearchResponse = postService.readAll(postSearchRequest);
 
         // then
-        assertThat(postsSearchJejuResponse.posts().stream().map(PostSearchResponse::postId).toList()).containsExactly(
-                jejuJuly.postId(), jejuMay.postId());
-        assertThat(postsSearchJulyResponse.posts().stream().map(PostSearchResponse::postId).toList()).containsExactly(
-                seoulJuly.postId(), jejuJuly.postId());
-
+        assertThat(postsSearchResponse.posts())
+                .containsExactly(PostSearchResponse.from(seoulJulyPost), PostSearchResponse.from(jejuJulyPost));
     }
 
     @Test
     void 감상을_수정한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        Post post = postRepository.save(새로운_감상(point, member.id(), "", trip.id()));
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
 
         // when
-        postService.update(loginUser, postCreateResponse.postId(), postUpdateRequest, null);
+        postService.update(loginUser, post.id(), postUpdateRequest, null);
 
         // then
-        PostResponse postResponseBeforeUpdate = postService.read(postCreateResponse.postId());
-
+        Post updatedPost = postRepository.getByPostId(post.id());
         assertSoftly(softly -> {
-            softly.assertThat(postResponseBeforeUpdate.postId()).isEqualTo(postCreateResponse.postId());
-            softly.assertThat(postResponseBeforeUpdate.title()).isEqualTo("우도의 땅콩 아이스크림");
-            softly.assertThat(postResponseBeforeUpdate.writing()).isEqualTo("수정한 내용입니다.");
+            softly.assertThat(updatedPost.title()).isEqualTo("우도의 땅콩 아이스크림");
+            softly.assertThat(updatedPost.writing()).isEqualTo("수정한 내용입니다.");
         });
     }
 
     @Test
     void 감상을_수정할_때_존재하지_않는_감상_ID이면_예외를_발생시킨다() {
         // given
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
 
         // expect
         assertThatThrownBy(() -> postService.update(loginUser, Long.MIN_VALUE, postUpdateRequest, null))
@@ -335,16 +298,12 @@ class PostServiceTest {
     @Test
     void 감상을_수정할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
         LoginUser wrongUser = new LoginUser(Long.MIN_VALUE);
 
         // expect
-        Long postId = postCreateResponse.postId();
-        assertThatThrownBy(() -> postService.update(wrongUser, postId, postUpdateRequest, null))
+        assertThatThrownBy(() -> postService.update(wrongUser, post.id(), postUpdateRequest, null))
                 .isInstanceOf(PostException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_POST.message());
     }
@@ -352,15 +311,13 @@ class PostServiceTest {
     @Test
     void 감상을_수정할_때_로그인_한_사용자가_감상의_작성자가_아니면_예외가_발생한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        Member otherMember = memberRepository.save(다른_사용자());
+        LoginUser otherUser = new LoginUser(otherMember.id());
+        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
 
         // expect
-        Long postId = postCreateResponse.postId();
-        assertThatThrownBy(() -> postService.update(otherUser, postId, postUpdateRequest, null))
+        assertThatThrownBy(() -> postService.update(otherUser, post.id(), postUpdateRequest, null))
                 .isInstanceOf(PostException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_POST.message());
     }
@@ -368,13 +325,14 @@ class PostServiceTest {
     @Test
     void 감상을_삭제한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
+        LoginUser loginUser = new LoginUser(member.id());
+        Post post = postRepository.save(새로운_감상(point, member.id()));
 
-        // expect
-        Long postId = postCreateResponse.postId();
-        assertDoesNotThrow(() -> postService.delete(loginUser, postId));
+        // when
+        postService.delete(loginUser, post.id());
 
-        assertThatThrownBy(() -> postService.read(postId))
+        // then
+        assertThatThrownBy(() -> postService.read(post.id()))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.message());
     }
@@ -382,7 +340,7 @@ class PostServiceTest {
     @Test
     void 감상을_삭제할_때_존재하지_않는_감상_ID이면_예외를_발생시킨다() {
         // expect
-        assertThatThrownBy(() -> postService.delete(loginUser, Long.MIN_VALUE))
+        assertThatThrownBy(() -> postService.delete(new LoginUser(member.id()), Long.MIN_VALUE))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.message());
     }
@@ -390,12 +348,11 @@ class PostServiceTest {
     @Test
     void 감상을_삭제할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
-        LoginUser wrongUser = new LoginUser(Long.MIN_VALUE);
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        LoginUser invalidUser = new LoginUser(Long.MIN_VALUE);
 
         // expect
-        Long postId = postCreateResponse.postId();
-        assertThatThrownBy(() -> postService.delete(wrongUser, postId))
+        assertThatThrownBy(() -> postService.delete(invalidUser, post.id()))
                 .isInstanceOf(PostException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_POST.message());
     }
@@ -403,11 +360,12 @@ class PostServiceTest {
     @Test
     void 감상을_삭제할_때_로그인_한_사용자가_감상의_작성자가_아니면_예외가_발생한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        Member otherMember = memberRepository.save(다른_사용자());
+        LoginUser otherUser = new LoginUser(otherMember.id());
 
         // expect
-        Long postId = postCreateResponse.postId();
-        assertThatThrownBy(() -> postService.delete(otherUser, postId))
+        assertThatThrownBy(() -> postService.delete(otherUser, post.id()))
                 .isInstanceOf(PostException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_POST.message());
     }
@@ -415,15 +373,8 @@ class PostServiceTest {
     @Test
     void 이미지를_저장하는_경우_여행의_대표이미지도_변경한다() {
         // given
-        PostAndPointCreateRequest request = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        LoginUser loginUser = new LoginUser(member.id());
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(trip.id());
         MultipartFile multipartFile = mock(MultipartFile.class);
         given(fileUploader.upload(any())).willReturn("hello.png");
 
@@ -434,15 +385,27 @@ class PostServiceTest {
         assertThat(trip.imageUrl()).isEqualTo("hello.png");
     }
 
-    private PostCreateResponse createPost(String address, LocalDateTime localDateTime) {
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                address,
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                localDateTime);
-        return postService.addAtCurrentPoint(loginUser, postAndPointCreateRequest, null);
+    static class PostDtoFixture {
+        public static PostAndPointCreateRequest 현재_위치_감상_생성_요청(Long tripId) {
+            return new PostAndPointCreateRequest(
+                    tripId,
+                    "우도의 바닷가",
+                    "제주특별자치도 제주시 애월읍",
+                    "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                    1.1,
+                    2.2,
+                    LocalDateTime.of(2023, 7, 18, 20, 24)
+            );
+        }
+
+        public static PostRequest 감상_생성_요청(Long tripId, Long pointId) {
+            return new PostRequest(
+                    tripId,
+                    pointId,
+                    "우도의 바닷가",
+                    "제주특별자치도 제주시 애월읍",
+                    "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+            );
+        }
     }
 }

--- a/backend/src/test/java/dev/tripdraw/post/domain/PostTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/domain/PostTest.java
@@ -1,13 +1,13 @@
 package dev.tripdraw.post.domain;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
 import static dev.tripdraw.post.exception.PostExceptionType.NOT_AUTHORIZED_TO_POST;
+import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
+import static dev.tripdraw.test.fixture.PointFixture.위치정보;
 import static dev.tripdraw.trip.exception.TripExceptionType.POINT_ALREADY_HAS_POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.post.exception.PostException;
 import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.exception.TripException;
@@ -21,52 +21,44 @@ import org.junit.jupiter.api.Test;
 class PostTest {
 
     @Test
-    void 위치를_가져온다() {
+    void 감상에_저장된_위치정보의_시간을_가져온다() {
         // given
         LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Post post = new Post("제목", 새로운_위치정보(recordedAt), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
 
         // expect
         assertThat(post.pointRecordedAt()).isEqualTo(recordedAt);
     }
 
     @Test
-    void 인가된_사용자는_예외가_발생하지_않는다() {
+    void 사용자의_감상인지_확인한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member(1L, "통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Long memberId = 1L;
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", memberId, 1L);
 
         // expect
-        assertThatNoException().isThrownBy(() -> post.validateAuthorization(member.id()));
+        assertThatNoException().isThrownBy(() -> post.validateAuthorization(memberId));
     }
 
     @Test
-    void 인가되지_않은_사용자는_예외가_발생한다() {
+    void 사용자의_감상이_아니라면_예외가_발생한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member(1L, "통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Long memberId = 1L;
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", memberId, 1L);
 
         // expect
-        assertThatThrownBy(() -> post.validateAuthorization(new Member(2L, "순후추", "kakaoId", KAKAO).id()))
+        assertThatThrownBy(() -> post.validateAuthorization(Long.MAX_VALUE))
                 .isInstanceOf(PostException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_POST.message());
     }
 
     @Test
-    void 감상을_생성할_때_감상의_위치에_감상을_등록한다() {
+    void 감상을_생성할_때_저장된_위치정보에_감상이_존재한다고_변경한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
+        Point point = 위치정보();
 
         // when
-        new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
 
         // then
         assertThat(point.hasPost()).isTrue();
@@ -75,13 +67,11 @@ class PostTest {
     @Test
     void 감상을_생성할_때_감상의_위치에_이미_감상이_등록되어_있다면_예외가_발생한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
+        Point point = 위치정보();
         point.registerPost();
-        Member member = new Member("통후추", "kakaoId", KAKAO);
 
         // expect
-        assertThatThrownBy(() -> new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L))
+        assertThatThrownBy(() -> new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", 1L, 1L))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_ALREADY_HAS_POST.message());
     }
@@ -89,10 +79,7 @@ class PostTest {
     @Test
     void 감상의_제목을_수정한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
 
         // when
         post.changeTitle("바뀐 제목");
@@ -104,10 +91,7 @@ class PostTest {
     @Test
     void 감상의_내용을_수정한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
 
         // when
         post.changeWriting("내일은 바람이 많네요.");
@@ -119,10 +103,7 @@ class PostTest {
     @Test
     void 감상_사진_URL을_변경한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
 
         // when
         post.changePostImageUrl("/통후추셀카.jpg");
@@ -134,10 +115,7 @@ class PostTest {
     @Test
     void 경로_이미지_URL을_변경한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
 
         // when
         post.changeRouteImageUrl("/통후추여행경로.png");
@@ -149,10 +127,7 @@ class PostTest {
     @Test
     void 감상의_사진_URL을_제거한다() {
         // given
-        LocalDateTime recordedAt = LocalDateTime.now();
-        Point point = new Point(3.14, 5.25, recordedAt);
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Post post = new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", member.id(), 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
         post.changePostImageUrl("example.url");
 
         // when

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -1,6 +1,12 @@
 package dev.tripdraw.post.presentation;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.post.presentation.PostControllerTest.PostRequestFixture.감상_생성_요청;
+import static dev.tripdraw.post.presentation.PostControllerTest.PostRequestFixture.멀티파트_요청;
+import static dev.tripdraw.post.presentation.PostControllerTest.PostRequestFixture.현재_위치_감상_생성_요청;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
+import static dev.tripdraw.test.fixture.PostFixture.새로운_감상;
+import static dev.tripdraw.test.fixture.TripFixture.새로운_여행;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -16,6 +22,8 @@ import dev.tripdraw.auth.application.JwtTokenProvider;
 import dev.tripdraw.draw.application.RouteImageGenerator;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
+import dev.tripdraw.post.domain.Post;
+import dev.tripdraw.post.domain.PostRepository;
 import dev.tripdraw.post.dto.PostAndPointCreateRequest;
 import dev.tripdraw.post.dto.PostCreateResponse;
 import dev.tripdraw.post.dto.PostRequest;
@@ -24,18 +32,18 @@ import dev.tripdraw.post.dto.PostUpdateRequest;
 import dev.tripdraw.post.dto.PostsResponse;
 import dev.tripdraw.post.dto.PostsSearchResponse;
 import dev.tripdraw.test.ControllerTest;
+import dev.tripdraw.trip.domain.Point;
+import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
-import dev.tripdraw.trip.dto.PointCreateRequest;
-import dev.tripdraw.trip.dto.PointResponse;
 import io.restassured.RestAssured;
 import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.MultiPartSpecification;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -47,10 +55,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PostControllerTest extends ControllerTest {
 
-    private static final String WRONG_TOKEN = "wrong.long.token";
+    private static final String INVALID_TOKEN = "wrong.long.token";
+
+    @Autowired
+    private PostRepository postRepository;
 
     @Autowired
     private TripRepository tripRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -62,67 +76,50 @@ class PostControllerTest extends ControllerTest {
     @MockBean
     private RouteImageGenerator routeImageGenerator;
 
+    private Member member;
     private Trip trip;
-    private String huchuToken;
+    private Point point;
+    private String accessToken;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
-
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        trip = tripRepository.save(Trip.of(member.id(), member.nickname()));
-        huchuToken = jwtTokenProvider.generateAccessToken(member.id().toString());
+        member = memberRepository.save(사용자());
+        trip = tripRepository.save(새로운_여행(member));
+        point = pointRepository.save(새로운_위치정보(trip));
+        accessToken = jwtTokenProvider.generateAccessToken(member.id().toString());
     }
 
     @Test
     void 현재_위치에_대한_감상을_생성한다() {
         // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(trip.id());
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts/current-location")
                 .then().log().all()
+                .statusCode(CREATED.value())
                 .extract();
 
         // then
         PostCreateResponse postCreateResponse = response.as(PostCreateResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(CREATED.value());
-            softly.assertThat(postCreateResponse.postId()).isNotNull();
-        });
+        assertThat(postCreateResponse.postId()).isNotNull();
     }
 
     @Test
     void 현재_위치에_대한_감상을_생성할_때_인증에_실패하면_예외를_발생시킨다() {
         // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(trip.id());
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(INVALID_TOKEN)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(UNAUTHORIZED.value());
@@ -131,21 +128,13 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                Long.MIN_VALUE,
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(Long.MAX_VALUE);
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -154,21 +143,13 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_제목이_비어있으면_예외를_발생시킨다() {
         // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(trip.id(), "");
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -177,44 +158,14 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 현재_위치에_대한_감상을_생성할_때_제목이_100자를_초과하면_예외를_발생시킨다() {
         // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "a".repeat(101),
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        String invalidTitle = "A".repeat(101);
+        PostAndPointCreateRequest request = 현재_위치_감상_생성_요청(trip.id(), invalidTitle);
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
-                .when().post("/posts/current-location")
-                .then().log().all()
-                .statusCode(BAD_REQUEST.value());
-    }
-
-    @Test
-    void 현재_위치에_대한_감상을_생성할_때_위도가_존재하지_않으면_예외를_발생시킨다() {
-        // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                null,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
-
-        // expect
-        RestAssured.given().log().all()
-                .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postAndPointCreateRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts/current-location")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -223,52 +174,33 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성한다() {
         // given
-        PointResponse pointResponse = createPoint();
-
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                pointResponse.pointId(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        PostRequest request = 감상_생성_요청(trip.id(), point.id());
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts")
                 .then().log().all()
+                .statusCode(CREATED.value())
                 .extract();
 
         // then
         PostCreateResponse postCreateResponse = response.as(PostCreateResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(CREATED.value());
-            softly.assertThat(postCreateResponse.postId()).isNotNull();
-        });
+        assertThat(postCreateResponse.postId()).isNotNull();
     }
 
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_인증에_실패하면_예외를_발생시킨다() {
         // given
-        PointResponse pointResponse = createPoint();
-
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                pointResponse.pointId(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        PostRequest request = 감상_생성_요청(trip.id(), point.id());
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(INVALID_TOKEN)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(UNAUTHORIZED.value());
@@ -277,21 +209,14 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
-        PointResponse pointResponse = createPoint();
-
-        PostRequest postRequest = new PostRequest(
-                Long.MIN_VALUE,
-                pointResponse.pointId(),
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        Long invalidTripId = Long.MAX_VALUE;
+        PostRequest request = 감상_생성_요청(invalidTripId, point.id());
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -300,65 +225,30 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_위치의_ID이면_예외를_발생시킨다() {
         // given
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                Long.MIN_VALUE,
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        Long invalidPointId = Long.MAX_VALUE;
+        PostRequest request = 감상_생성_요청(trip.id(), invalidPointId);
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
     }
 
     @Test
-    void 사용자가_선택한_위치에_대한_감상을_생성할_때_주소가_비어있으면_예외를_발생시킨다() {
-        // given
-        PointResponse pointResponse = createPoint();
-
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                pointResponse.pointId(),
-                "우도의 바닷가",
-                null,
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
-
-        // expect
-        RestAssured.given().log().all()
-                .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
-                .when().post("/posts")
-                .then().log().all()
-                .statusCode(BAD_REQUEST.value());
-    }
-
-    @Test
     void 사용자가_선택한_위치에_대한_감상을_생성할_때_제목이_100자를_초과하면_예외를_발생시킨다() {
         // given
-        PointResponse pointResponse = createPoint();
-
-        PostRequest postRequest = new PostRequest(
-                trip.id(),
-                pointResponse.pointId(),
-                "a".repeat(101),
-                "제주특별자치도 제주시 애월읍",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
-        );
+        String invalidTitle = "A".repeat(101);
+        PostRequest request = 감상_생성_요청(trip.id(), point.id(), invalidTitle);
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart("dto", postRequest, APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart("dto", request, APPLICATION_JSON_VALUE)
                 .when().post("/posts")
                 .then().log().all()
                 .statusCode(BAD_REQUEST.value());
@@ -367,42 +257,27 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 특정_감상을_조회한다() {
         // given
-        PostCreateResponse postResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 20, 24));
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        updateHasPost(List.of(point));
 
         // when
-        ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .when().get("/posts/{postId}", postResponse.postId())
+                .auth().preemptive().oauth2(accessToken)
+                .when().get("/posts/{postId}", post.id())
                 .then().log().all()
+                .statusCode(OK.value())
                 .extract();
 
-        PostResponse getResponse = findResponse.as(PostResponse.class);
-
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(findResponse.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(getResponse.postId()).isNotNull();
-            softly.assertThat(getResponse.title()).isEqualTo("우도의 바닷가");
-            softly.assertThat(getResponse.pointResponse().pointId()).isNotNull();
-            softly.assertThat(getResponse.pointResponse().latitude()).isEqualTo(1.1);
-            softly.assertThat(getResponse.postImageUrl()).isEmpty();
-            softly.assertThat(getResponse.routeImageUrl()).isEmpty();
-        });
+        PostResponse postResponse = response.as(PostResponse.class);
+        assertThat(postResponse).usingRecursiveComparison()
+                .ignoringFieldsOfTypes(LocalDateTime.class)
+                .isEqualTo(PostResponse.from(post));
     }
 
-    @Test
-    void 특정_감상을_조회할_때_인증에_실패하면_예외가_발생한다() {
-        // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 20, 24));
-
-        // expect
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .when().get("/posts/{postId}", postCreateResponse.postId())
-                .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+    private void updateHasPost(final List<Point> points) {
+        pointRepository.saveAll(points);
     }
 
     @Test
@@ -410,8 +285,8 @@ class PostControllerTest extends ControllerTest {
         // given & expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .when().get("/posts/{postId}", -1)
+                .auth().preemptive().oauth2(accessToken)
+                .when().get("/posts/{postId}", Long.MAX_VALUE)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
     }
@@ -419,104 +294,74 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 특정_여행에_대한_모든_감상을_조회한다() {
         // given
-        createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 20, 24));
-        createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 21, 24));
+        Point point1 = pointRepository.save(새로운_위치정보(trip));
+        Point point2 = pointRepository.save(새로운_위치정보(trip));
+        Post post1 = postRepository.save(새로운_감상(point1, member.id()));
+        Post post2 = postRepository.save(새로운_감상(point2, member.id()));
+        updateHasPost(List.of(point1, point2));
 
         // when
         ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
+                .auth().preemptive().oauth2(accessToken)
                 .when().get("/trips/{tripId}/posts", trip.id())
                 .then().log().all()
+                .statusCode(OK.value())
                 .extract();
 
-        PostsResponse postsResponse = findResponse.as(PostsResponse.class);
-
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(findResponse.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(postsResponse.posts().get(0).postId()).isNotNull();
-            softly.assertThat(postsResponse.posts().get(0).title()).isEqualTo("우도의 바닷가");
-            softly.assertThat(postsResponse.posts().get(0).pointResponse().pointId()).isNotNull();
-            softly.assertThat(postsResponse.posts().get(0).pointResponse().latitude()).isEqualTo(1.1);
-            softly.assertThat(postsResponse.posts().get(1).postId()).isNotNull();
-            softly.assertThat(postsResponse.posts().get(1).title()).isEqualTo("우도의 바닷가");
-            softly.assertThat(postsResponse.posts().get(1).pointResponse().pointId()).isNotNull();
-            softly.assertThat(postsResponse.posts().get(1).pointResponse().latitude()).isEqualTo(1.1);
-        });
-    }
-
-    @Test
-    void 특정_여행에_대한_모든_감상을_조회할_때_인증에_실패하면_예외가_발생한다() {
-        // given & expect
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .when().get("/trips/{tripId}/posts", trip.id())
-                .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+        PostsResponse postsResponse = findResponse.as(PostsResponse.class);
+        assertThat(postsResponse.posts()).usingRecursiveComparison()
+                .ignoringFieldsOfTypes(LocalDateTime.class)
+                .isEqualTo(List.of(PostResponse.from(post2), PostResponse.from(post1)));
     }
 
     @Test
     void 특정_여행에_대한_모든_감상을_조회할_때_존재하지_않는_여행의_ID이면_예외가_발생한다() {
-        // given & expect
+        // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
+                .auth().preemptive().oauth2(accessToken)
                 .when().get("/trips/{tripId}/posts", Long.MIN_VALUE)
                 .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+                .statusCode(NOT_FOUND.value());
     }
 
     @Test
     void 감상을_수정한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.now());
-
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
-
-        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postUpdateRequest);
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        PostUpdateRequest request = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
+        RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart(multiPartSpecification)
-                .when().patch("/posts/{postId}", postCreateResponse.postId())
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart(멀티파트_요청(request))
+                .when().patch("/posts/{postId}", post.id())
                 .then().log().all()
-                .extract();
+                .statusCode(NO_CONTENT.value());
 
         // then
-        PostResponse postResponse = readPost(postCreateResponse.postId());
-
+        Post updatedPost = postRepository.getByPostId(post.id());
         assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(NO_CONTENT.value());
-            softly.assertThat(postResponse.title()).isEqualTo("우도의 땅콩 아이스크림");
-            softly.assertThat(postResponse.writing()).isEqualTo("수정한 내용입니다.");
+            softly.assertThat(updatedPost.title()).isEqualTo("우도의 땅콩 아이스크림");
+            softly.assertThat(updatedPost.writing()).isEqualTo("수정한 내용입니다.");
         });
     }
 
     @Test
     void 감상을_수정할_때_인증에_실패하면_예외가_발생한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 20, 24));
-
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
-
-        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postUpdateRequest);
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        PostUpdateRequest request = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .multiPart(multiPartSpecification)
-                .when().patch("/posts/{postId}", postCreateResponse.postId())
+                .auth().preemptive().oauth2(INVALID_TOKEN)
+                .multiPart(멀티파트_요청(request))
+                .when().patch("/posts/{postId}", post.id())
                 .then().log().all()
                 .statusCode(UNAUTHORIZED.value());
     }
@@ -524,18 +369,13 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 감상을_수정할_때_존재하지_않는_여행의_ID이면_예외가_발생한다() {
         // given
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(
-                "우도의 땅콩 아이스크림",
-                "수정한 내용입니다."
-        );
-
-        MultiPartSpecification multiPartSpecification = getMultiPartSpecification(postUpdateRequest);
+        PostUpdateRequest request = new PostUpdateRequest("우도의 땅콩 아이스크림", "수정한 내용입니다.");
 
         // expect
         RestAssured.given().log().all()
                 .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart(multiPartSpecification)
+                .auth().preemptive().oauth2(accessToken)
+                .multiPart(멀티파트_요청(request))
                 .when().patch("/posts/{postId}", Long.MIN_VALUE)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
@@ -544,190 +384,123 @@ class PostControllerTest extends ControllerTest {
     @Test
     void 감상을_삭제한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 20, 24));
+        Post post = postRepository.save(새로운_감상(point, member.id()));
 
-        // expect1 : 삭제하면 204 NO_CONTENT 응답
-        RestAssured.given().log().all()
+        // when
+        ExtractableResponse<Response> firstResponse = RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .when().delete("/posts/{postId}", postCreateResponse.postId())
+                .auth().preemptive().oauth2(accessToken)
+                .when().delete("/posts/{postId}", post.id())
                 .then().log().all()
-                .statusCode(NO_CONTENT.value());
+                .extract();
+        ExtractableResponse<Response> secondResponse = RestAssured.given().log().all()
+                .contentType(APPLICATION_JSON_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .when().get("/posts/{postId}", post.id())
+                .then().log().all()
+                .extract();
 
-        // expect2 : 다시 조회하면 404 NOT_FOUND 응답
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .when().get("/posts/{postId}", postCreateResponse.postId())
-                .then().log().all()
-                .statusCode(NOT_FOUND.value());
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(firstResponse.statusCode()).isEqualTo(NO_CONTENT.value());
+            softly.assertThat(secondResponse.statusCode()).isEqualTo(NOT_FOUND.value());
+        });
     }
 
     @Test
     void 감상을_삭제할_때_인증에_실패하면_예외가_발생한다() {
         // given
-        PostCreateResponse postCreateResponse = createPost("제주특별자치도 제주시 애월읍", LocalDateTime.of(2023, 7, 18, 20, 24));
+        Post post = postRepository.save(새로운_감상(point, member.id()));
 
         // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .when().delete("/posts/{postId}", postCreateResponse.postId())
+                .auth().preemptive().oauth2(INVALID_TOKEN)
+                .when().delete("/posts/{postId}", post.id())
                 .then().log().all()
                 .statusCode(UNAUTHORIZED.value());
     }
 
     @Test
-    void 감상을_삭제할_때_존재하지_않는_여행의_ID이면_예외가_발생한다() {
-        // given & expect
-        RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .when().delete("/posts/{postId}", Long.MIN_VALUE)
-                .then().log().all()
-                .statusCode(NOT_FOUND.value());
-    }
-
-    @Test
     void 다른_사용자들의_감상을_조회한다() {
         // given
-        PostCreateResponse jejuJuly20hourPostResponse = createPost("제주특별자치도 제주시 애월읍",
-                LocalDateTime.of(2023, 7, 18, 20, 24));
-        PostCreateResponse jejuAugust17hourPostResponse = createPost("제주특별자치도 제주시 애월읍",
-                LocalDateTime.of(2023, 8, 18, 17, 24));
-        PostCreateResponse jejuSeptember17hourPostResponse = createPost("제주특별자치도 제주시 애월읍",
-                LocalDateTime.of(2023, 9, 18, 17, 24));
-        PostCreateResponse seoulSeptember17hourPostResponse = createPost("서울특별시 송파구 잠실동",
-                LocalDateTime.of(2023, 9, 18, 17, 24));
-
-        Map<String, Object> jejuParams = Map.of(
-                "address", "제주특별자치도 제주시 애월읍",
-                "limit", 10
-        );
-
-        Map<String, Object> jejuHour17Params = Map.of(
-                "hours", Set.of(17),
-                "address", "제주특별자치도 제주시 애월읍",
-                "limit", 10
-        );
-
-        Map<String, Object> hour17Params = Map.of(
-                "hours", Set.of(17),
-                "limit", 10
-        );
+        Point julyPoint = pointRepository.save(새로운_위치정보(LocalDateTime.of(2023, 7, 18, 20, 24)));
+        Point augustPoint = pointRepository.save(새로운_위치정보(LocalDateTime.of(2023, 8, 18, 17, 24)));
+        Point septemberPoint = pointRepository.save(새로운_위치정보(LocalDateTime.of(2023, 9, 18, 17, 24)));
+        Post jejuJulyPost = postRepository.save(새로운_감상(julyPoint, member.id(), "제주특별자치도 제주시 애월읍"));
+        Post jejuAugustPost = postRepository.save(새로운_감상(augustPoint, member.id(), "제주특별자치도 제주시 애월읍"));
+        Post seoulSeptemberPost = postRepository.save(새로운_감상(septemberPoint, member.id(), "서울특별시 송파구 잠실동"));
+        updateHasPost(List.of(julyPoint, augustPoint, septemberPoint));
+        Map<String, Object> params = Map.of("address", "제주특별자치도 제주시 애월읍", "limit", 10);
 
         // when
         ExtractableResponse<Response> jejuResponse = RestAssured.given().log().all()
-                .auth().preemptive().oauth2(huchuToken)
-                .params(jejuParams)
-                .when().get("/posts")
-                .then().log().all()
-                .statusCode(OK.value())
-                .extract();
-
-        ExtractableResponse<Response> jejuhour17Response = RestAssured.given().log().all()
-                .auth().preemptive().oauth2(huchuToken)
-                .params(jejuHour17Params)
-                .when().get("/posts")
-                .then().log().all()
-                .statusCode(OK.value())
-                .extract();
-
-        ExtractableResponse<Response> hour17Response = RestAssured.given().log().all()
-                .auth().preemptive().oauth2(huchuToken)
-                .params(hour17Params)
+                .auth().preemptive().oauth2(accessToken)
+                .params(params)
                 .when().get("/posts")
                 .then().log().all()
                 .statusCode(OK.value())
                 .extract();
 
         // then
-        PostsSearchResponse jejuPostsSearchResponse = jejuResponse.as(PostsSearchResponse.class);
-        PostsSearchResponse jeju17hourPostsSearchResponse = jejuhour17Response.as(PostsSearchResponse.class);
-        PostsSearchResponse hour17PostsSearchResponse = hour17Response.as(PostsSearchResponse.class);
-
-        assertThat(jejuPostsSearchResponse.posts().get(0).postId()).isEqualTo(jejuSeptember17hourPostResponse.postId());
-        assertThat(jejuPostsSearchResponse.posts().get(1).postId()).isEqualTo(jejuAugust17hourPostResponse.postId());
-        assertThat(jejuPostsSearchResponse.posts().get(2).postId()).isEqualTo(jejuJuly20hourPostResponse.postId());
-
-        assertThat(jeju17hourPostsSearchResponse.posts().get(0).postId()).isEqualTo(
-                jejuSeptember17hourPostResponse.postId());
-        assertThat(jeju17hourPostsSearchResponse.posts().get(1).postId()).isEqualTo(
-                jejuAugust17hourPostResponse.postId());
-
-        assertThat(hour17PostsSearchResponse.posts().get(0).postId()).isEqualTo(
-                seoulSeptember17hourPostResponse.postId());
-        assertThat(hour17PostsSearchResponse.posts().get(1).postId()).isEqualTo(
-                jejuSeptember17hourPostResponse.postId());
-        assertThat(hour17PostsSearchResponse.posts().get(2).postId()).isEqualTo(jejuAugust17hourPostResponse.postId());
+        PostsSearchResponse response = jejuResponse.as(PostsSearchResponse.class);
+        assertThat(response.posts()).usingRecursiveComparison()
+                .ignoringFieldsOfTypes(LocalDateTime.class)
+                .isEqualTo(List.of(PostResponse.from(jejuAugustPost), PostResponse.from(jejuJulyPost)));
     }
 
-    private PointResponse createPoint() {
-        PointCreateRequest request = new PointCreateRequest(
-                trip.id(),
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+    static class PostRequestFixture {
+        public static PostAndPointCreateRequest 현재_위치_감상_생성_요청(Long tripId) {
+            return new PostAndPointCreateRequest(
+                    tripId,
+                    "우도의 바닷가",
+                    "제주특별자치도 제주시 애월읍",
+                    "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                    1.1,
+                    2.2,
+                    LocalDateTime.of(2023, 7, 18, 20, 24)
+            );
+        }
 
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .body(request)
-                .when().post("/points")
-                .then().log().all()
-                .extract();
+        public static PostAndPointCreateRequest 현재_위치_감상_생성_요청(Long tripId, String title) {
+            return new PostAndPointCreateRequest(
+                    tripId,
+                    title,
+                    "제주특별자치도 제주시 애월읍",
+                    "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
+                    1.1,
+                    2.2,
+                    LocalDateTime.of(2023, 7, 18, 20, 24)
+            );
+        }
 
-        return response.as(PointResponse.class);
-    }
+        public static PostRequest 감상_생성_요청(Long tripId, Long pointId) {
+            return new PostRequest(
+                    tripId,
+                    pointId,
+                    "우도의 바닷가",
+                    "제주특별자치도 제주시 애월읍",
+                    "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+            );
+        }
 
-    private PostCreateResponse createPost(String address, LocalDateTime localDateTime) {
-        // given
-        PostAndPointCreateRequest postAndPointCreateRequest = new PostAndPointCreateRequest(
-                trip.id(),
-                "우도의 바닷가",
-                address,
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                localDateTime
-        );
+        public static PostRequest 감상_생성_요청(Long tripId, Long pointId, String title) {
+            return new PostRequest(
+                    tripId,
+                    pointId,
+                    title,
+                    "제주특별자치도 제주시 애월읍",
+                    "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다."
+            );
+        }
 
-        MultiPartSpecification multiPartSpecification = new MultiPartSpecBuilder(postAndPointCreateRequest)
-                .fileName("postAndPointCreateRequest")
-                .controlName("dto")
-                .mimeType("application/json")
-                .charset("UTF-8")
-                .build();
-
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .contentType(MULTIPART_FORM_DATA_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .multiPart(multiPartSpecification)
-                .when().post("/posts/current-location")
-                .then().log().all()
-                .extract();
-
-        return createResponse.as(PostCreateResponse.class);
-    }
-
-    PostResponse readPost(Long postId) {
-        ExtractableResponse<Response> findResponse = RestAssured.given().log().all()
-                .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(huchuToken)
-                .when().get("/posts/{postId}", postId)
-                .then().log().all()
-                .extract();
-
-        return findResponse.as(PostResponse.class);
-    }
-
-    private MultiPartSpecification getMultiPartSpecification(Object request) {
-        return new MultiPartSpecBuilder(request)
-                .fileName("request")
-                .controlName("dto")
-                .mimeType("application/json")
-                .charset("UTF-8")
-                .build();
+        public static MultiPartSpecification 멀티파트_요청(Object request) {
+            return new MultiPartSpecBuilder(request)
+                    .fileName("request")
+                    .controlName("dto")
+                    .mimeType("application/json")
+                    .charset("UTF-8")
+                    .build();
+        }
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/TestKakaoApiClient.java
+++ b/backend/src/test/java/dev/tripdraw/test/TestKakaoApiClient.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.test;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.AuthFixture.OAuth_정보;
 
 import dev.tripdraw.auth.dto.OauthInfo;
 import dev.tripdraw.auth.oauth.OauthClient;
@@ -15,6 +16,6 @@ public class TestKakaoApiClient implements OauthClient {
 
     @Override
     public OauthInfo requestOauthInfo(String accessToken) {
-        return new OauthInfo("kakaoId", KAKAO);
+        return OAuth_정보();
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/AuthFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/AuthFixture.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.test.fixture;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.OAUTH_아이디;
 
 import dev.tripdraw.auth.config.AccessTokenConfig;
 import dev.tripdraw.auth.config.RefreshTokenConfig;
@@ -8,6 +9,7 @@ import dev.tripdraw.auth.dto.OauthInfo;
 
 public class AuthFixture {
 
+    public static final String OAUTH_TOKEN = "KAKAO.OAUTH.TOKEN";
     private static final long INVALID_TOKEN_EXPIRE_TIME = -180000L;
     private static final String ACCESS_TOKEN_KEY =
             "ACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKEN";
@@ -33,6 +35,6 @@ public class AuthFixture {
     }
 
     public static OauthInfo OAuth_정보() {
-        return new OauthInfo("id", KAKAO);
+        return new OauthInfo(OAUTH_아이디, KAKAO);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/AuthFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/AuthFixture.java
@@ -1,10 +1,13 @@
 package dev.tripdraw.test.fixture;
 
+import static dev.tripdraw.common.auth.OauthType.KAKAO;
+
 import dev.tripdraw.auth.config.AccessTokenConfig;
 import dev.tripdraw.auth.config.RefreshTokenConfig;
+import dev.tripdraw.auth.dto.OauthInfo;
 
 public class AuthFixture {
-    
+
     private static final long INVALID_TOKEN_EXPIRE_TIME = -180000L;
     private static final String ACCESS_TOKEN_KEY =
             "ACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKEN";
@@ -27,5 +30,9 @@ public class AuthFixture {
 
     public static RefreshTokenConfig 만료된_토큰_생성용_REFRESH_TOKEN_설정() {
         return new RefreshTokenConfig(REFRESH_TOKEN_KEY, INVALID_TOKEN_EXPIRE_TIME);
+    }
+
+    public static OauthInfo OAuth_정보() {
+        return new OauthInfo("id", KAKAO);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/AuthFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/AuthFixture.java
@@ -4,8 +4,7 @@ import dev.tripdraw.auth.config.AccessTokenConfig;
 import dev.tripdraw.auth.config.RefreshTokenConfig;
 
 public class AuthFixture {
-
-    public static final String 유효하지_않은_토큰 = "Invalid.Token.XD";
+    
     private static final long INVALID_TOKEN_EXPIRE_TIME = -180000L;
     private static final String ACCESS_TOKEN_KEY =
             "ACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKENACCESSTOKEN";

--- a/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
@@ -5,7 +5,13 @@ import dev.tripdraw.member.domain.Member;
 
 public class MemberFixture {
 
+    public static String OAUTH_아이디 = "TRIPDRAW";
+
     public static Member 사용자() {
-        return new Member(1L, "통후추", "", OauthType.KAKAO);
+        return new Member(1L, "통후추", OAUTH_아이디, OauthType.KAKAO);
+    }
+
+    public static Member 닉네임이_없는_사용자() {
+        return Member.of(OAUTH_아이디, OauthType.KAKAO);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
@@ -15,6 +15,10 @@ public class MemberFixture {
         return new Member("순후추", "OTHER_ID", OauthType.KAKAO);
     }
 
+    public static Member 새로운_사용자(String nickname) {
+        return new Member(nickname, OAUTH_아이디 + nickname, OauthType.KAKAO);
+    }
+
     public static Member 닉네임이_없는_사용자() {
         return Member.of(OAUTH_아이디, OauthType.KAKAO);
     }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
@@ -11,6 +11,10 @@ public class MemberFixture {
         return new Member(1L, "통후추", OAUTH_아이디, OauthType.KAKAO);
     }
 
+    public static Member 다른_사용자() {
+        return new Member("순후추", "OTHER_ID", OauthType.KAKAO);
+    }
+
     public static Member 닉네임이_없는_사용자() {
         return Member.of(OAUTH_아이디, OauthType.KAKAO);
     }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/PointFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/PointFixture.java
@@ -20,4 +20,8 @@ public class PointFixture {
     public static Point 새로운_위치정보(int year, int month, int dayOfMonth, int hour, int minute) {
         return new Point(1.1, 2.2, LocalDateTime.of(year, month, dayOfMonth, hour, minute));
     }
+
+    public static Point 새로운_위치정보(LocalDateTime localDateTime) {
+        return new Point(1.1, 2.2, localDateTime);
+    }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/PointFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/PointFixture.java
@@ -1,0 +1,18 @@
+package dev.tripdraw.test.fixture;
+
+import static dev.tripdraw.test.fixture.TripFixture.여행;
+
+import dev.tripdraw.trip.domain.Point;
+import java.time.LocalDateTime;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class PointFixture {
+
+    public static Point 위치정보() {
+        return new Point(1L, 1.1, 2.2, false, LocalDateTime.now(), 여행());
+    }
+
+    public static Point 위치정보(int year, int month, int dayOfMonth, int hour, int minute) {
+        return new Point(1.1, 2.2, LocalDateTime.of(year, month, dayOfMonth, hour, minute));
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/test/fixture/PointFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/PointFixture.java
@@ -3,6 +3,7 @@ package dev.tripdraw.test.fixture;
 import static dev.tripdraw.test.fixture.TripFixture.여행;
 
 import dev.tripdraw.trip.domain.Point;
+import dev.tripdraw.trip.domain.Trip;
 import java.time.LocalDateTime;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -12,7 +13,11 @@ public class PointFixture {
         return new Point(1L, 1.1, 2.2, false, LocalDateTime.now(), 여행());
     }
 
-    public static Point 위치정보(int year, int month, int dayOfMonth, int hour, int minute) {
+    public static Point 새로운_위치정보(Trip trip) {
+        return new Point(1.1, 2.2, LocalDateTime.now(), trip);
+    }
+
+    public static Point 새로운_위치정보(int year, int month, int dayOfMonth, int hour, int minute) {
         return new Point(1.1, 2.2, LocalDateTime.of(year, month, dayOfMonth, hour, minute));
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/PostFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/PostFixture.java
@@ -1,0 +1,13 @@
+package dev.tripdraw.test.fixture;
+
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static dev.tripdraw.test.fixture.PointFixture.위치정보;
+
+import dev.tripdraw.post.domain.Post;
+
+public class PostFixture {
+
+    public static Post 감상() {
+        return new Post("감상 제목", 위치정보(), "주소", "감상", 사용자().id(), 1L);
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/test/fixture/PostFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/PostFixture.java
@@ -4,10 +4,23 @@ import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static dev.tripdraw.test.fixture.PointFixture.위치정보;
 
 import dev.tripdraw.post.domain.Post;
+import dev.tripdraw.trip.domain.Point;
 
 public class PostFixture {
 
     public static Post 감상() {
-        return new Post("감상 제목", 위치정보(), "주소", "감상", 사용자().id(), 1L);
+        return new Post(1L, "감상 제목", 위치정보(), "주소", "감상", 사용자().id(), 1L);
+    }
+
+    public static Post 새로운_감상(Point point, Long memberId) {
+        return new Post("감상 제목", point, "주소", "감상", memberId, 1L);
+    }
+
+    public static Post 새로운_감상(Point point, Long memberId, String address) {
+        return new Post("감상 제목", point, address, "감상", memberId, 1L);
+    }
+
+    public static Post 새로운_감상(Point point, Long memberId, String address, Long tripId) {
+        return new Post("감상 제목", point, address, "감상", memberId, tripId);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/TestFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/TestFixture.java
@@ -2,40 +2,13 @@ package dev.tripdraw.test.fixture;
 
 import static dev.tripdraw.trip.domain.TripStatus.FINISHED;
 
-import dev.tripdraw.common.auth.OauthType;
-import dev.tripdraw.member.domain.Member;
-import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.post.dto.PostAndPointCreateRequest;
-import dev.tripdraw.trip.domain.Point;
-import dev.tripdraw.trip.domain.Trip;
-import dev.tripdraw.trip.domain.TripName;
-import dev.tripdraw.trip.domain.TripStatus;
 import dev.tripdraw.trip.dto.PointCreateRequest;
 import dev.tripdraw.trip.dto.TripUpdateRequest;
 import java.time.LocalDateTime;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class TestFixture {
-
-    public static Member 사용자() {
-        return new Member(1L, "통후추", "", OauthType.KAKAO);
-    }
-
-    public static Point 위치정보() {
-        return new Point(1L, 1.1, 2.2, false, LocalDateTime.now(), 여행());
-    }
-
-    public static Point 위치정보(int year, int month, int dayOfMonth, int hour, int minute) {
-        return new Point(1.1, 2.2, LocalDateTime.of(year, month, dayOfMonth, hour, minute));
-    }
-
-    public static Trip 여행() {
-        return new Trip(1L, TripName.from("통후추"), 사용자().id(), TripStatus.ONGOING, "", "");
-    }
-
-    public static Post 감상() {
-        return new Post("감상 제목", 위치정보(), "주소", "감상", 사용자().id(), 1L);
-    }
 
     public static PointCreateRequest pointCreateRequest(Long tripId) {
         return new PointCreateRequest(
@@ -48,18 +21,6 @@ public class TestFixture {
 
     public static TripUpdateRequest tripUpdateRequest() {
         return new TripUpdateRequest("제주도 여행", FINISHED);
-    }
-
-    public static PostAndPointCreateRequest postAndPointCreateRequest(Long tripId) {
-        return new PostAndPointCreateRequest(
-                tripId,
-                "우도의 바닷가",
-                "제주특별자치도 제주시 애월읍 소길리",
-                "우도에서 땅콩 아이스크림을 먹었다.\\n너무 맛있었다.",
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
     }
 
     public static PostAndPointCreateRequest 제주_2023_2_1_수(Long tripId) {

--- a/backend/src/test/java/dev/tripdraw/test/fixture/TripFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/TripFixture.java
@@ -1,0 +1,15 @@
+package dev.tripdraw.test.fixture;
+
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+
+import dev.tripdraw.trip.domain.Trip;
+import dev.tripdraw.trip.domain.TripName;
+import dev.tripdraw.trip.domain.TripStatus;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class TripFixture {
+
+    public static Trip 여행() {
+        return new Trip(1L, TripName.from("통후추"), 사용자().id(), TripStatus.ONGOING, "", "");
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/test/fixture/TripFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/TripFixture.java
@@ -2,6 +2,7 @@ package dev.tripdraw.test.fixture;
 
 import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 
+import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripName;
 import dev.tripdraw.trip.domain.TripStatus;
@@ -11,5 +12,9 @@ public class TripFixture {
 
     public static Trip 여행() {
         return new Trip(1L, TripName.from("통후추"), 사용자().id(), TripStatus.ONGOING, "", "");
+    }
+
+    public static Trip 새로운_여행(Member member) {
+        return new Trip(TripName.from(member.nickname()), member.id());
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/acceptance/TripSearchAcceptanceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/acceptance/TripSearchAcceptanceTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.trip.acceptance;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.새로운_사용자;
 import static dev.tripdraw.test.fixture.TestFixture.서울_2022_1_2_일;
 import static dev.tripdraw.test.fixture.TestFixture.서울_2023_1_1_일;
 import static dev.tripdraw.test.fixture.TestFixture.양양_2021_3_2_화;
@@ -69,9 +69,9 @@ public class TripSearchAcceptanceTest extends ControllerTest {
     public void setUp() {
         super.setUp();
 
-        Member huchu = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        Member reo = memberRepository.save(new Member("리오", "kakaoId", KAKAO));
-        Member herb = memberRepository.save(new Member("허브", "kakaoId", KAKAO));
+        Member huchu = memberRepository.save(새로운_사용자("통후추"));
+        Member reo = memberRepository.save(새로운_사용자("리오"));
+        Member herb = memberRepository.save(새로운_사용자("허브"));
 
         huchuToken = jwtTokenProvider.generateAccessToken(huchu.id().toString());
         String reoToken = jwtTokenProvider.generateAccessToken(reo.id().toString());
@@ -94,7 +94,6 @@ public class TripSearchAcceptanceTest extends ControllerTest {
 
         lastViewedId = 허브_제주_2023_2_1_수;
     }
-
 
     @Nested
     class 감상이_있는_모든_여행을_페이지네이션으로_조회할_때 {

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripDeleteEventHandlerTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripDeleteEventHandlerTest.java
@@ -2,7 +2,7 @@ package dev.tripdraw.trip.application;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.times;
 
 import dev.tripdraw.member.domain.MemberDeleteEvent;
 import dev.tripdraw.trip.domain.PointRepository;
@@ -34,14 +34,13 @@ class TripDeleteEventHandlerTest {
     void 회원_삭제_이벤트를_받아_회원의_여행을_삭제한다() {
         // given
         MemberDeleteEvent memberDeleteEvent = new MemberDeleteEvent(1L);
-
         List<Long> tripIds = List.of(1L);
         given(tripRepository.findAllTripIdsByMemberId(memberDeleteEvent.memberId()))
-                .willReturn(tripIds);
+                .willReturn(List.of(1L));
 
         // when
         tripDeleteEventHandler.deletePostByMemberId(memberDeleteEvent);
-        
+
         // then
         then(tripRepository)
                 .should(times(1))

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripQueryServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripQueryServiceTest.java
@@ -1,10 +1,17 @@
 package dev.tripdraw.trip.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
+
 import dev.tripdraw.test.fixture.TripSearchConditionsFixture;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.dto.TripSearchConditions;
 import dev.tripdraw.trip.query.TripCustomRepository;
 import dev.tripdraw.trip.query.TripPaging;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -12,14 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
@@ -1,6 +1,10 @@
 package dev.tripdraw.trip.application;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
+import static dev.tripdraw.test.fixture.PostFixture.새로운_감상;
+import static dev.tripdraw.test.fixture.TripFixture.새로운_여행;
+import static dev.tripdraw.trip.application.TripServiceTest.PostRequestFixture.위치정보_생성_요청;
 import static dev.tripdraw.trip.domain.TripStatus.FINISHED;
 import static dev.tripdraw.trip.exception.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
@@ -12,10 +16,9 @@ import dev.tripdraw.common.auth.LoginUser;
 import dev.tripdraw.draw.application.RouteImageGenerator;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
-import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.post.domain.PostRepository;
-import dev.tripdraw.test.ServiceTest;
 import dev.tripdraw.trip.domain.Point;
+import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
 import dev.tripdraw.trip.dto.PointCreateRequest;
@@ -24,21 +27,25 @@ import dev.tripdraw.trip.dto.PointResponse;
 import dev.tripdraw.trip.dto.TripCreateResponse;
 import dev.tripdraw.trip.dto.TripResponse;
 import dev.tripdraw.trip.dto.TripSearchRequest;
-import dev.tripdraw.trip.dto.TripSearchResponse;
-import dev.tripdraw.trip.dto.TripSearchResponseOfMember;
 import dev.tripdraw.trip.dto.TripUpdateRequest;
 import dev.tripdraw.trip.dto.TripsSearchResponse;
 import dev.tripdraw.trip.dto.TripsSearchResponseOfMember;
 import dev.tripdraw.trip.exception.TripException;
+import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@ServiceTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Transactional
+@SpringBootTest
 class TripServiceTest {
 
     @Autowired
@@ -51,23 +58,26 @@ class TripServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private PostRepository postRepository;
+    private PointRepository pointRepository;
 
     @MockBean
     private RouteImageGenerator routeImageGenerator;
 
+    @Autowired
+    private PostRepository postRepository;
+
     private Trip trip;
+    private Point point;
     private LoginUser loginUser;
 
     @BeforeEach
     void setUp() {
-        Member member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        Trip trip = Trip.of(member.id(), member.nickname());
-        Point point = new Point(3.14, 5.25, LocalDateTime.now());
+        Member member = memberRepository.save(사용자());
+        trip = tripRepository.save(새로운_여행(member));
+        point = pointRepository.save(새로운_위치정보(trip));
         trip.add(point);
-        this.trip = tripRepository.save(trip);
         loginUser = new LoginUser(member.id());
-        postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member.id(), trip.id()));
+        postRepository.save(새로운_감상(point, member.id()));
     }
 
     @Test
@@ -82,20 +92,23 @@ class TripServiceTest {
     @Test
     void 여행에_위치정보를_추가한다() {
         // given
-        PointCreateRequest pointCreateRequest = new PointCreateRequest(trip.id(), 1.1, 2.2, LocalDateTime.now());
+        PointCreateRequest pointCreateRequest = 위치정보_생성_요청(trip.id());
 
         // when
         PointCreateResponse response = tripService.addPoint(loginUser, pointCreateRequest);
 
         // then
-        assertThat(response.pointId()).isNotNull();
+        Trip savedTrip = tripRepository.getById(trip.id());
+        assertThat(savedTrip.points())
+                .extracting(Point::id)
+                .contains(response.pointId());
     }
 
     @Test
     void 여행에_위치정보를_추가할_때_해당_여행이_존재하지_않으면_예외를_발생시킨다() {
         // given
-        Long nonExistentId = Long.MIN_VALUE;
-        PointCreateRequest pointCreateRequest = new PointCreateRequest(nonExistentId, 1.1, 2.2, LocalDateTime.now());
+        Long invalidTripId = Long.MIN_VALUE;
+        PointCreateRequest pointCreateRequest = 위치정보_생성_요청(invalidTripId);
 
         // expect
         assertThatThrownBy(() -> tripService.addPoint(loginUser, pointCreateRequest))
@@ -105,90 +118,57 @@ class TripServiceTest {
 
     @Test
     void 여행을_ID로_조회한다() {
-        // given & when
+        // when
         TripResponse tripResponse = tripService.readTripById(loginUser, trip.id());
 
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(tripResponse.tripId()).isNotNull();
-            softly.assertThat(tripResponse.name()).isNotNull();
-            softly.assertThat(tripResponse.route()).isNotNull();
-            softly.assertThat(tripResponse.status()).isNotNull();
-        });
+        // expect
+        assertThat(tripResponse).isEqualTo(TripResponse.from(trip));
     }
 
     @Test
     void 여행에서_위치정보를_삭제한다() {
-        // given
-        PointCreateRequest pointCreateRequest = new PointCreateRequest(trip.id(), 1.1, 2.2, LocalDateTime.now());
-        PointCreateResponse response = tripService.addPoint(loginUser, pointCreateRequest);
-
         // when
-        tripService.deletePoint(loginUser, response.pointId(), trip.id());
+        tripService.deletePoint(loginUser, point.id(), trip.id());
 
         // then
-        boolean expected = trip.route().points()
-                .stream()
-                .anyMatch(point -> Objects.equals(point.id(), response.pointId()));
-
-        assertThat(expected).isTrue();
+        assertThat(pointRepository.findById(point.id())).isEmpty();
     }
 
     @Test
     void 여행에서_위치정보를_삭제시_인가에_실패하면_예외를_발생시킨다() {
         // given
-        PointCreateRequest pointCreateRequest = new PointCreateRequest(trip.id(), 1.1, 2.2, LocalDateTime.now());
-        PointCreateResponse response = tripService.addPoint(loginUser, pointCreateRequest);
         LoginUser otherUser = new LoginUser(Long.MIN_VALUE);
 
         // expect
-        assertThatThrownBy(() -> tripService.deletePoint(otherUser, response.pointId(), trip.id()))
+        assertThatThrownBy(() -> tripService.deletePoint(otherUser, point.id(), trip.id()))
                 .isInstanceOf(TripException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_TRIP.message());
     }
 
     @Test
     void 특정_회원의_전체_여행을_조회한다() {
-        // given & when
+        // when
         TripsSearchResponseOfMember tripsSearchResponseOfMember = tripService.readAllTripsOf(loginUser);
 
         // then
-        assertThat(tripsSearchResponseOfMember).usingRecursiveComparison().isEqualTo(
-                new TripsSearchResponseOfMember(List.of(
-                        new TripSearchResponseOfMember(
-                                trip.id(),
-                                trip.nameValue(),
-                                trip.imageUrl(),
-                                trip.routeImageUrl()
-                        )
-                ))
-        );
+        assertThat(tripsSearchResponseOfMember).usingRecursiveComparison()
+                .isEqualTo(TripsSearchResponseOfMember.from(List.of(trip)));
     }
 
     @Test
     void 모든_회원의_감상이_있는_여행_전체를_조회한다() {
         // given
-        TripSearchRequest tripSearchRequest = TripSearchRequest.builder()
+        TripSearchRequest request = TripSearchRequest.builder()
                 .limit(10)
                 .build();
 
         // when
-        TripsSearchResponse tripsSearchResponse = tripService.readAll(tripSearchRequest);
+        TripsSearchResponse tripsSearchResponse = tripService.readAll(request);
 
         // then
-        assertThat(tripsSearchResponse).usingRecursiveComparison().isEqualTo(
-                new TripsSearchResponse(List.of(
-                        new TripSearchResponse(
-                                trip.id(),
-                                trip.nameValue(),
-                                trip.imageUrl(),
-                                trip.routeImageUrl(),
-                                trip.createdAt(),
-                                trip.updatedAt()
-                        )),
-                        false
-                )
-        );
+        assertThat(tripsSearchResponse).usingRecursiveComparison()
+                .ignoringFieldsOfTypes(LocalDateTime.class)
+                .isEqualTo(TripsSearchResponse.of(List.of(trip), false));
     }
 
     @Test
@@ -200,6 +180,7 @@ class TripServiceTest {
         tripService.updateTripById(loginUser, trip.id(), request);
 
         // then
+        Trip trip = tripRepository.getById(this.trip.id());
         assertSoftly(softly -> {
             softly.assertThat(trip.nameValue()).isEqualTo("제주도 여행");
             softly.assertThat(trip.status()).isEqualTo(FINISHED);
@@ -208,27 +189,16 @@ class TripServiceTest {
 
     @Test
     void 위치_정보를_조회한다() {
-        // given
-        PointCreateRequest pointCreateRequest = new PointCreateRequest(
-                trip.id(),
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
-        Long pointId = tripService.addPoint(loginUser, pointCreateRequest).pointId();
-
         // when
-        PointResponse pointResponse = tripService.readPointByTripAndPointId(loginUser, trip.id(), pointId);
+        PointResponse pointResponse = tripService.readPointByTripAndPointId(loginUser, trip.id(), point.id());
 
         // then
-        assertThat(pointResponse).usingRecursiveComparison().isEqualTo(
-                new PointResponse(
-                        pointId,
-                        1.1,
-                        2.2,
-                        false,
-                        LocalDateTime.of(2023, 7, 18, 20, 24)
-                )
-        );
+        assertThat(pointResponse).usingRecursiveComparison().isEqualTo(PointResponse.from(point));
+    }
+
+    static class PostRequestFixture {
+        public static PointCreateRequest 위치정보_생성_요청(Long tripId) {
+            return new PointCreateRequest(tripId, 1.1, 2.2, LocalDateTime.now());
+        }
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
@@ -77,7 +77,7 @@ class TripServiceTest {
         point = pointRepository.save(새로운_위치정보(trip));
         trip.add(point);
         loginUser = new LoginUser(member.id());
-        postRepository.save(새로운_감상(point, member.id()));
+        postRepository.save(새로운_감상(point, member.id(), "", trip.id()));
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/trip/domain/TripRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/domain/TripRepositoryTest.java
@@ -1,11 +1,19 @@
 package dev.tripdraw.trip.domain;
 
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
+import static dev.tripdraw.test.fixture.TripFixture.새로운_여행;
+import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
 import dev.tripdraw.common.config.JpaConfig;
 import dev.tripdraw.common.config.QueryDslConfig;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.trip.exception.TripException;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,17 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.IntStream;
-
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
-import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -45,28 +42,24 @@ class TripRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        member = memberRepository.save(사용자());
     }
 
     @Test
     void 회원_ID로_여행_목록을_조회한다() {
         // given
-        Trip trip = new Trip(TripName.from("제주도 여행"), member.id());
-        tripRepository.save(trip);
+        Trip trip = tripRepository.save(새로운_여행(member));
 
         // when
         List<Trip> trips = tripRepository.findAllByMemberId(member.id());
 
         // then
-        assertSoftly(softly -> {
-            softly.assertThat(trips).hasSize(1);
-            softly.assertThat(trips.get(0)).isEqualTo(trip);
-        });
+        assertThat(trips).containsExactly(trip);
     }
 
     @Test
     void 회원_ID로_여행_목록을_조회할_때_해당_회원의_여행이_없다면_빈_여행_목록을_반환한다() {
-        // given & when
+        // when
         List<Trip> trips = tripRepository.findAllByMemberId(member.id());
 
         // then
@@ -76,9 +69,9 @@ class TripRepositoryTest {
     @Test
     void 여행_ID를_입력받아_여행_목록과_위치_정보까지_조회한다() {
         // given
-        Trip trip = new Trip(TripName.from("제주도 여행"), member.id());
-        Point point1 = new Point(1.1, 2.2, LocalDateTime.now());
-        Point point2 = new Point(3.3, 4.4, LocalDateTime.now());
+        Trip trip = 새로운_여행(member);
+        Point point1 = 새로운_위치정보(trip);
+        Point point2 = 새로운_위치정보(trip);
         trip.add(point1);
         trip.add(point2);
         tripRepository.save(trip);
@@ -96,8 +89,7 @@ class TripRepositoryTest {
     @Test
     void 회원_ID로_여행을_삭제한다() {
         // given
-        Trip trip = new Trip(TripName.from("제주도 여행"), member.id());
-        tripRepository.save(trip);
+        Trip trip = tripRepository.save(새로운_여행(member));
 
         // when
         tripRepository.deleteByMemberId(member.id());
@@ -109,7 +101,7 @@ class TripRepositoryTest {
     @Test
     void 여행_ID로_여행을_조회한다() {
         // given
-        Trip trip = tripRepository.save(new Trip(TripName.from("제주도 여행"), member.id()));
+        Trip trip = tripRepository.save(새로운_여행(member));
 
         // when
         Trip foundTrip = tripRepository.getById(trip.id());
@@ -121,10 +113,10 @@ class TripRepositoryTest {
     @Test
     void 여행_ID로_여행을_조회할_때_존재하지_않는_경우_예외를_발생시킨다() {
         // given
-        Long wrongId = Long.MIN_VALUE;
+        Long invalidId = Long.MIN_VALUE;
 
         // expect
-        assertThatThrownBy(() -> tripRepository.getById(wrongId))
+        assertThatThrownBy(() -> tripRepository.getById(invalidId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.message());
     }
@@ -133,7 +125,7 @@ class TripRepositoryTest {
     void 회원_ID를_갖는_모든_여행_ID를_조회한다() {
         // given
         List<Long> tripIds = IntStream.range(0, 5)
-                .mapToObj(value -> tripRepository.save(Trip.of(member.id(), member.nickname())).id())
+                .mapToObj(value -> tripRepository.save(새로운_여행(member)).id())
                 .toList();
 
         // when

--- a/backend/src/test/java/dev/tripdraw/trip/domain/TripTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/domain/TripTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.trip.domain;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
+import static dev.tripdraw.test.fixture.TripFixture.새로운_여행;
 import static dev.tripdraw.trip.exception.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_INVALID_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,6 +13,7 @@ import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.trip.exception.TripException;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
@@ -23,11 +25,17 @@ import org.junit.jupiter.params.provider.CsvSource;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class TripTest {
 
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = 사용자();
+    }
+
     @Test
     void 여행_경로에_좌표를_추가한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
         Point point = new Point(1.1, 2.2, LocalDateTime.now());
 
         // when
@@ -41,38 +49,10 @@ class TripTest {
         });
     }
 
-    @Nested
-    class 위치정보_포함_여부를_확인할_때 {
-
-        @Test
-        void 위치정보를_포함하는_여행이면_참값을_반환한다() {
-            // given
-            Member member = new Member("통후추", "kakaoId", KAKAO);
-            Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = new Point(1.1, 2.2, LocalDateTime.now());
-            trip.add(point);
-
-            // expect
-            assertThat(trip.contains(point)).isTrue();
-        }
-
-        @Test
-        void 위치정보를_포함하지_않는_여행이면_참값을_반환하지_않는다() {
-            // given
-            Member member = new Member("통후추", "kakaoId", KAKAO);
-            Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = new Point(1.1, 2.2, LocalDateTime.now());
-
-            // expect
-            assertThat(trip.contains(point)).isFalse();
-        }
-    }
-
     @Test
     void 인가된_사용자는_예외가_발생하지_않는다() {
         // given
-        Member member = new Member(1L, "tonghuchu", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
 
         // expect
         assertThatNoException().isThrownBy(() -> trip.validateAuthorization(member.id()));
@@ -81,11 +61,11 @@ class TripTest {
     @Test
     void 인가되지_않은_사용자는_예외가_발생한다() {
         // given
-        Member member = new Member(1L, "tonghuchu", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
+        Long invalidId = Long.MAX_VALUE;
 
         // expect
-        assertThatThrownBy(() -> trip.validateAuthorization(new Member(2L, "other", "kakaoId", KAKAO).id()))
+        assertThatThrownBy(() -> trip.validateAuthorization(invalidId))
                 .isInstanceOf(TripException.class)
                 .hasMessage(NOT_AUTHORIZED_TO_TRIP.message());
     }
@@ -93,8 +73,7 @@ class TripTest {
     @Test
     void 이름을_반환한다() {
         // given
-        Member member = new Member("tonghuchu", "kakaoId", KAKAO);
-        Trip trip = new Trip(TripName.from("통후추"), member.id());
+        Trip trip = 새로운_여행(member);
 
         // expect
         assertThat(trip.nameValue()).isEqualTo("통후추의 여행");
@@ -103,8 +82,7 @@ class TripTest {
     @Test
     void 이름을_변경한다() {
         // given
-        Member member = new Member("tonghuchu", "kakaoId", KAKAO);
-        Trip trip = new Trip(TripName.from("통후추"), member.id());
+        Trip trip = 새로운_여행(member);
 
         // when
         trip.changeName("제주도 여행");
@@ -116,8 +94,7 @@ class TripTest {
     @Test
     void 경로에_해당하는_모든_위치를_반환한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
         Point point1 = new Point(1.1, 2.2, LocalDateTime.now());
         Point point2 = new Point(3.3, 4.4, LocalDateTime.now());
         trip.add(point1);
@@ -134,8 +111,7 @@ class TripTest {
     @CsvSource({"ONGOING, ONGOING", "FINISHED, FINISHED"})
     void 여행_상태를_변경한다(TripStatus target, TripStatus expected) {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
 
         // when
         trip.changeStatus(target);
@@ -147,8 +123,7 @@ class TripTest {
     @Test
     void 여행_상태를_null로_변경하려할_경우_예외를_발생시킨다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
 
         // expect
         assertThatThrownBy(() -> trip.changeStatus(null))
@@ -159,8 +134,7 @@ class TripTest {
     @Test
     void 감상_사진_URL을_변경한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
 
         // when
         trip.changeImageUrl("/통후추셀카.jpg");
@@ -172,8 +146,7 @@ class TripTest {
     @Test
     void 경로_이미지_URL을_변경한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
 
         // when
         trip.changeRouteImageUrl("/통후추여행경로.png");
@@ -185,8 +158,7 @@ class TripTest {
     @Test
     void 위도를_반환한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
         trip.add(new Point(1.1, 2.2, LocalDateTime.now()));
         trip.add(new Point(3.3, 4.4, LocalDateTime.now()));
         trip.add(new Point(5.5, 6.6, LocalDateTime.now()));
@@ -201,8 +173,7 @@ class TripTest {
     @Test
     void 경도를_반환한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
         trip.add(new Point(1.1, 2.2, LocalDateTime.now()));
         trip.add(new Point(3.3, 4.4, LocalDateTime.now()));
         trip.add(new Point(5.5, 6.6, LocalDateTime.now()));
@@ -217,8 +188,7 @@ class TripTest {
     @Test
     void 감상을_남긴_위치_정보의_위도를_반환한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
         trip.add(new Point(1.1, 2.2, true, LocalDateTime.now()));
         trip.add(new Point(3.3, 4.4, false, LocalDateTime.now()));
         trip.add(new Point(5.5, 6.6, true, LocalDateTime.now()));
@@ -233,8 +203,7 @@ class TripTest {
     @Test
     void 감상을_남긴_위치_정보의_경도를_반환한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = 새로운_여행(member);
         trip.add(new Point(1.1, 2.2, true, LocalDateTime.now()));
         trip.add(new Point(3.3, 4.4, false, LocalDateTime.now()));
         trip.add(new Point(5.5, 6.6, true, LocalDateTime.now()));
@@ -244,5 +213,30 @@ class TripTest {
 
         // then
         assertThat(pointedLongitudes).containsExactly(2.2, 6.6);
+    }
+
+    @Nested
+    class 위치정보_포함_여부를_확인할_때 {
+
+        @Test
+        void 위치정보를_포함하는_여행이면_참값을_반환한다() {
+            // given
+            Trip trip = 새로운_여행(member);
+            Point point = new Point(1.1, 2.2, LocalDateTime.now());
+            trip.add(point);
+
+            // expect
+            assertThat(trip.contains(point)).isTrue();
+        }
+
+        @Test
+        void 위치정보를_포함하지_않는_여행이면_참값을_반환하지_않는다() {
+            // given
+            Trip trip = 새로운_여행(member);
+            Point point = new Point(1.1, 2.2, LocalDateTime.now());
+
+            // expect
+            assertThat(trip.contains(point)).isFalse();
+        }
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/dto/PointCreateRequestTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/dto/PointCreateRequestTest.java
@@ -15,19 +15,13 @@ class PointCreateRequestTest {
     @Test
     void 위치_객체로_변환한다() {
         // given
-        PointCreateRequest request = new PointCreateRequest(
-                1L,
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        LocalDateTime recordedAt = LocalDateTime.of(2023, 7, 18, 20, 24);
+        PointCreateRequest request = new PointCreateRequest(1L, 1.1, 2.2, recordedAt);
 
         // when
         Point point = request.toPoint();
 
         // then
-        assertThat(point).usingRecursiveComparison().isEqualTo(
-                new Point(1.1, 2.2, LocalDateTime.of(2023, 7, 18, 20, 24))
-        );
+        assertThat(point).usingRecursiveComparison().isEqualTo(new Point(1.1, 2.2, recordedAt));
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/dto/TripSearchResponseOfMemberTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/dto/TripSearchResponseOfMemberTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.trip.dto;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static dev.tripdraw.trip.domain.TripStatus.ONGOING;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,7 +18,7 @@ class TripSearchResponseOfMemberTest {
     @Test
     void 여행_이미지와_경로_이미지가_null이면_빈값으로_변환해_생성한다() {
         // given
-        Member member = new Member("통후추", "kakaoId", KAKAO);
+        Member member = 사용자();
         TripName tripName = TripName.from("통후추의 여행");
         Trip trip = new Trip(1L, tripName, member.id(), ONGOING, null, null);
 

--- a/backend/src/test/java/dev/tripdraw/trip/presentation/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/presentation/TripControllerTest.java
@@ -1,22 +1,21 @@
 package dev.tripdraw.trip.presentation;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
-import static dev.tripdraw.test.fixture.TestFixture.pointCreateRequest;
-import static dev.tripdraw.test.fixture.TestFixture.tripUpdateRequest;
+import static dev.tripdraw.test.fixture.MemberFixture.새로운_사용자;
+import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
 import static dev.tripdraw.test.fixture.TestFixture.서울_2022_1_2_일;
 import static dev.tripdraw.test.fixture.TestFixture.서울_2023_1_1_일;
 import static dev.tripdraw.test.fixture.TestFixture.제주_2023_1_1_일;
+import static dev.tripdraw.test.fixture.TripFixture.새로운_여행;
 import static dev.tripdraw.test.step.PostStep.createPostAtCurrentPoint;
-import static dev.tripdraw.test.step.TripStep.addPointAndGetResponse;
 import static dev.tripdraw.test.step.TripStep.createTripAndGetResponse;
-import static dev.tripdraw.test.step.TripStep.searchTripAndGetResponse;
-import static dev.tripdraw.test.step.TripStep.updateTrip;
 import static dev.tripdraw.trip.domain.TripStatus.FINISHED;
+import static dev.tripdraw.trip.presentation.TripControllerTest.PostRequestFixture.위치정보_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import dev.tripdraw.auth.application.JwtTokenProvider;
@@ -24,13 +23,16 @@ import dev.tripdraw.draw.application.RouteImageGenerator;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.test.ControllerTest;
+import dev.tripdraw.trip.domain.Point;
+import dev.tripdraw.trip.domain.PointRepository;
+import dev.tripdraw.trip.domain.Trip;
+import dev.tripdraw.trip.domain.TripRepository;
 import dev.tripdraw.trip.dto.PointCreateRequest;
 import dev.tripdraw.trip.dto.PointCreateResponse;
 import dev.tripdraw.trip.dto.PointResponse;
 import dev.tripdraw.trip.dto.TripCreateResponse;
 import dev.tripdraw.trip.dto.TripResponse;
 import dev.tripdraw.trip.dto.TripSearchResponse;
-import dev.tripdraw.trip.dto.TripSearchResponseOfMember;
 import dev.tripdraw.trip.dto.TripUpdateRequest;
 import dev.tripdraw.trip.dto.TripsSearchResponse;
 import dev.tripdraw.trip.dto.TripsSearchResponseOfMember;
@@ -52,10 +54,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class TripControllerTest extends ControllerTest {
 
-    private static final String WRONG_TOKEN = "wrong.long.token";
-
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
@@ -64,56 +70,41 @@ class TripControllerTest extends ControllerTest {
     private RouteImageGenerator routeImageGenerator;
 
     private String huchuToken;
+    private Trip huchuTrip;
     private String reoToken;
+    private Trip reoTrip;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
 
-        Member huchu = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
-        Member reo = memberRepository.save(new Member("리오", "kakaoId", KAKAO));
+        Member huchu = memberRepository.save(새로운_사용자("통후추"));
+        Member reo = memberRepository.save(새로운_사용자("리오"));
         huchuToken = jwtTokenProvider.generateAccessToken(huchu.id().toString());
         reoToken = jwtTokenProvider.generateAccessToken(reo.id().toString());
+        huchuTrip = tripRepository.save(새로운_여행(huchu));
+        reoTrip = tripRepository.save(새로운_여행(reo));
     }
 
     @Test
     void 여행을_생성한다() {
-        // given & when
+        // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().preemptive().oauth2(huchuToken)
                 .when().post("/trips")
                 .then().log().all()
+                .statusCode(CREATED.value())
                 .extract();
 
         // then
         TripCreateResponse tripCreateResponse = response.as(TripCreateResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(CREATED.value());
-            softly.assertThat(tripCreateResponse.tripId()).isNotNull();
-        });
-    }
-
-    @Test
-    void 여행_생성_시_인증에_실패하면_예외를_발생시킨다() {
-        // given & expect
-        RestAssured.given().log().all()
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .when().post("/trips")
-                .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+        assertThat(tripCreateResponse.tripId()).isNotNull();
     }
 
     @Test
     void 여행에_위치_정보를_추가한다() {
         // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        PointCreateRequest request = new PointCreateRequest(
-                tripResponse.tripId(),
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        PointCreateRequest request = 위치정보_생성_요청(huchuTrip.id());
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -122,74 +113,55 @@ class TripControllerTest extends ControllerTest {
                 .body(request)
                 .when().post("/points")
                 .then().log().all()
+                .statusCode(CREATED.value())
                 .extract();
 
         // then
         PointCreateResponse pointCreateResponse = response.as(PointCreateResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(CREATED.value());
-            softly.assertThat(pointCreateResponse.pointId()).isNotNull();
-        });
+        assertThat(pointCreateResponse.pointId()).isNotNull();
     }
 
     @Test
     void 위치_정보_추가_시_인증에_실패하면_예외를_발생시킨다() {
         // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        PointCreateRequest request = new PointCreateRequest(
-                tripResponse.tripId(),
-                1.1,
-                2.2,
-                LocalDateTime.of(2023, 7, 18, 20, 24)
-        );
+        PointCreateRequest request = 위치정보_생성_요청(huchuTrip.id());
 
         // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
+                .auth().preemptive().oauth2(reoToken)
                 .body(request)
                 .when().post("/points")
                 .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+                .statusCode(FORBIDDEN.value());
     }
 
     @Test
     void 여행을_ID로_조회한다() {
-        // given
-        Long tripId = createTripAndGetResponse(huchuToken).tripId();
-
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().preemptive().oauth2(huchuToken)
-                .when().get("/trips/{tripId}", tripId)
+                .when().get("/trips/{tripId}", huchuTrip.id())
                 .then().log().all()
+                .statusCode(OK.value())
                 .extract();
 
         // then
         TripResponse tripResponse = response.as(TripResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(tripResponse.tripId()).isNotNull();
-            softly.assertThat(tripResponse.name()).isNotNull();
-            softly.assertThat(tripResponse.route()).isNotNull();
-            softly.assertThat(tripResponse.status()).isNotNull();
-        });
+        assertThat(tripResponse).isEqualTo(TripResponse.from(huchuTrip));
     }
 
     @Test
     void 특정_위치정보를_삭제한다() {
         // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        PointResponse pointResponse = addPointAndGetResponse(pointCreateRequest(tripResponse.tripId()), huchuToken);
+        Point point = pointRepository.save(새로운_위치정보(huchuTrip));
 
         // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(huchuToken)
-                .param("tripId", tripResponse.tripId())
-                .when().delete("/points/{pointId}", pointResponse.pointId())
+                .param("tripId", huchuTrip.id())
+                .when().delete("/points/{pointId}", point.id())
                 .then().log().all()
                 .statusCode(NO_CONTENT.value());
     }
@@ -197,133 +169,96 @@ class TripControllerTest extends ControllerTest {
     @Test
     void 특정_위치정보_삭제시_인증에_실패하면_예외를_발생시킨다() {
         // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        PointResponse pointResponse = addPointAndGetResponse(pointCreateRequest(tripResponse.tripId()), huchuToken);
+        Point point = pointRepository.save(새로운_위치정보(huchuTrip));
 
         // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .param("tripId", tripResponse.tripId())
-                .when().delete("/points/{pointId}", pointResponse.pointId())
+                .auth().preemptive().oauth2(reoToken)
+                .param("tripId", huchuTrip.id())
+                .when().delete("/points/{pointId}", point.id())
                 .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+                .statusCode(FORBIDDEN.value());
     }
 
     @Test
     void 특정_회원의_전체_여행을_조회한다() {
-        // given
-        Long tripId = createTripAndGetResponse(huchuToken).tripId();
-        updateTrip(tripUpdateRequest(), tripId, huchuToken);
-
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().preemptive().oauth2(huchuToken)
                 .when().get("/trips/me")
                 .then().log().all()
+                .statusCode(OK.value())
                 .extract();
 
         // then
         TripsSearchResponseOfMember tripsSearchResponseOfMember = response.as(TripsSearchResponseOfMember.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(tripsSearchResponseOfMember).usingRecursiveComparison().isEqualTo(
-                    new TripsSearchResponseOfMember(
-                            List.of(new TripSearchResponseOfMember(
-                                            tripId,
-                                            "제주도 여행",
-                                            "",
-                                            ""
-                                    )
-                            )
-                    )
-            );
-        });
+        assertThat(tripsSearchResponseOfMember)
+                .usingRecursiveComparison()
+                .isEqualTo(TripsSearchResponseOfMember.from(List.of(huchuTrip)));
     }
 
     @Test
     void 여행의_이름과_상태를_수정한다() {
         // given
-        Long tripId = createTripAndGetResponse(huchuToken).tripId();
         TripUpdateRequest tripUpdateRequest = new TripUpdateRequest("제주도 여행", FINISHED);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
+        RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(huchuToken)
                 .body(tripUpdateRequest)
-                .when().patch("/trips/{tripId}", tripId)
+                .when().patch("/trips/{tripId}", huchuTrip.id())
                 .then().log().all()
-                .extract();
+                .statusCode(NO_CONTENT.value());
 
         // then
-        TripResponse tripResponse = searchTripAndGetResponse(tripId, huchuToken);
-
+        Trip trip = tripRepository.getById(huchuTrip.id());
         assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(NO_CONTENT.value());
-            softly.assertThat(tripResponse.name()).isEqualTo("제주도 여행");
-            softly.assertThat(tripResponse.status()).isEqualTo(FINISHED);
+            softly.assertThat(trip.nameValue()).isEqualTo("제주도 여행");
+            softly.assertThat(trip.status()).isEqualTo(FINISHED);
         });
     }
 
     @Test
     void 위치_정보를_조회한다() {
         // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        Long pointId = addPointAndGetResponse(pointCreateRequest(tripResponse.tripId()), huchuToken).pointId();
+        Point point = pointRepository.save(새로운_위치정보(huchuTrip));
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .auth().preemptive().oauth2(huchuToken)
-                .param("tripId", tripResponse.tripId())
-                .when().get("/points/{pointId}", pointId)
+                .param("tripId", huchuTrip.id())
+                .when().get("/points/{pointId}", point.id())
                 .then().log().all()
+                .statusCode(OK.value())
                 .extract();
 
         // then
         PointResponse pointResponse = response.as(PointResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(pointResponse).usingRecursiveComparison().isEqualTo(
-                    new PointResponse(
-                            pointId,
-                            1.1,
-                            2.2,
-                            false,
-                            LocalDateTime.of(2023, 7, 18, 20, 24)
-                    )
-            );
-        });
+        assertThat(pointResponse).usingRecursiveComparison()
+                .ignoringFieldsOfTypes(LocalDateTime.class)
+                .isEqualTo(PointResponse.from(point));
     }
 
     @Test
     void 여행을_삭제한다() {
-        // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        Long tripId = tripResponse.tripId();
-
         // expect
         RestAssured.given().log().all()
                 .auth().preemptive().oauth2(huchuToken)
-                .when().delete("/trips/{tripId}", tripId)
+                .when().delete("/trips/{tripId}", huchuTrip.id())
                 .then().log().all()
                 .statusCode(NO_CONTENT.value());
     }
 
     @Test
     void 여행을_삭제할_때_인증에_실패하면_예외가_발생한다() {
-        // given
-        TripCreateResponse tripResponse = createTripAndGetResponse(huchuToken);
-        Long tripId = tripResponse.tripId();
-
         // expect
         RestAssured.given().log().all()
-                .auth().preemptive().oauth2(WRONG_TOKEN)
-                .when().delete("/trips/{tripId}", tripId)
+                .auth().preemptive().oauth2(reoToken)
+                .when().delete("/trips/{tripId}", huchuTrip.id())
                 .then().log().all()
-                .statusCode(UNAUTHORIZED.value());
+                .statusCode(FORBIDDEN.value());
     }
 
     @Test
@@ -351,22 +286,19 @@ class TripControllerTest extends ControllerTest {
                 .params(params)
                 .when().get("/trips")
                 .then().log().all()
+                .statusCode(OK.value())
                 .extract();
 
         // then
         TripsSearchResponse tripsSearchResponse = response.as(TripsSearchResponse.class);
-
-        assertSoftly(softly -> {
-            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(searchedTripIds(tripsSearchResponse)).containsExactly(
-                    리오_서울_2023_1_1_일
-            );
-        });
+        assertThat(tripsSearchResponse.trips())
+                .extracting(TripSearchResponse::tripId)
+                .containsExactly(리오_서울_2023_1_1_일);
     }
 
-    private List<Long> searchedTripIds(TripsSearchResponse tripsSearchResponse) {
-        return tripsSearchResponse.trips().stream()
-                .map(TripSearchResponse::tripId)
-                .toList();
+    static class PostRequestFixture {
+        public static PointCreateRequest 위치정보_생성_요청(Long tripId) {
+            return new PointCreateRequest(tripId, 1.1, 2.2, LocalDateTime.now());
+        }
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
@@ -1,7 +1,7 @@
 package dev.tripdraw.trip.query;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
-import static dev.tripdraw.test.fixture.TestFixture.위치정보;
+import static dev.tripdraw.test.fixture.PointFixture.위치정보;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.addressTripSearchConditions;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.daysOfWeekTripSearchConditions;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.emptyTripSearchConditions;

--- a/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
@@ -1,7 +1,6 @@
 package dev.tripdraw.trip.query;
 
 import static dev.tripdraw.common.auth.OauthType.KAKAO;
-import static dev.tripdraw.test.fixture.PointFixture.위치정보;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.addressTripSearchConditions;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.daysOfWeekTripSearchConditions;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.emptyTripSearchConditions;
@@ -13,6 +12,7 @@ import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
 import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.post.domain.PostRepository;
+import dev.tripdraw.test.fixture.PointFixture;
 import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
@@ -426,7 +426,7 @@ class TripCustomRepositoryImplTest {
 
         private Trip jeju_2023_2_1_Wed() {
             Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = 위치정보(2023, 2, 1, 1, 1);
+            Point point = PointFixture.새로운_위치정보(2023, 2, 1, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
             postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member.id(), trip.id()));
@@ -435,7 +435,7 @@ class TripCustomRepositoryImplTest {
 
         private Trip seoul_2023_1_1_Sun() {
             Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = 위치정보(2023, 1, 1, 10, 1);
+            Point point = PointFixture.새로운_위치정보(2023, 1, 1, 10, 1);
             trip.add(point);
             tripRepository.save(trip);
             postRepository.save(new Post("", point, "서울특별시 송파구 신천동", "", member.id(), trip.id()));
@@ -444,7 +444,7 @@ class TripCustomRepositoryImplTest {
 
         private Trip jeju_2023_1_1_Sun() {
             Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = 위치정보(2023, 1, 1, 1, 1);
+            Point point = PointFixture.새로운_위치정보(2023, 1, 1, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
             postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member.id(), trip.id()));
@@ -453,7 +453,7 @@ class TripCustomRepositoryImplTest {
 
         private Trip seoul_2022_1_2_Sun() {
             Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = 위치정보(2022, 1, 2, 1, 1);
+            Point point = PointFixture.새로운_위치정보(2022, 1, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
             postRepository.save(new Post("", point, "서울특별시 송파구 방이동", "", member.id(), trip.id()));
@@ -462,7 +462,7 @@ class TripCustomRepositoryImplTest {
 
         private Trip yangyang_2021_3_2_Tue() {
             Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = 위치정보(2021, 3, 2, 1, 1);
+            Point point = PointFixture.새로운_위치정보(2021, 3, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
             postRepository.save(new Post("", point, "강원도 양양군", "", member.id(), trip.id()));
@@ -471,7 +471,7 @@ class TripCustomRepositoryImplTest {
 
         private Trip emptyPostTrip() {
             Trip trip = Trip.of(member.id(), member.nickname());
-            Point point = 위치정보(2021, 3, 2, 1, 1);
+            Point point = PointFixture.새로운_위치정보(2021, 3, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
             return trip;

--- a/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
@@ -1,6 +1,6 @@
 package dev.tripdraw.trip.query;
 
-import static dev.tripdraw.common.auth.OauthType.KAKAO;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.addressTripSearchConditions;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.daysOfWeekTripSearchConditions;
 import static dev.tripdraw.test.fixture.TripSearchConditionsFixture.emptyTripSearchConditions;
@@ -52,7 +52,7 @@ class TripCustomRepositoryImplTest {
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(new Member("통후추", "kakaoId", KAKAO));
+        member = memberRepository.save(사용자());
     }
 
     @Nested


### PR DESCRIPTION
### 📌 관련 이슈

- closed #416 

### 📁 작업 설명

- 1차 TestFixture 적용했습니다.
- Trip query 쪽은 아직 완전히 적용은 하지 않았습니다.

### 작업 내용

- 전체적으로 BDDMockito 사용하도록 수정
- Member 테스트 양방향 의존 제거
- 일부 테스트에서 point의 경우 hasPost를 db에 반영하기 이해 위해 감상을 생성하고 난 뒤에 pointRepository.save로 추가로 실행.
- 기존의 감상 조회의 경우 인증이 필요했었는데, 다른 사람의 감상도 볼 수 있게 되면서 인증 실패에 대한 테스트를 제거.
- 일부 테스트의 검증이 올바르지 않은 부분을 수정 ex) 존재하지 않는 여행에 대한 검증이 인증 실패로 검증하는 경우
- status code에 대한 부분은 일관성을 위해 RestAssured에서 검증하도록 수정.
- 공통 인증과 관련된 부분을 제외.
- 올바르지 않은 인증 테스트를 수정.
