### PR TITLE
[feat] point Id를 통해 post를 조회하는 api (#461)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
@@ -29,6 +29,6 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**")
                 .excludePathPatterns("/oauth/**")
-                .excludePathPatterns("/actuator/**");
+                .excludePathPatterns("/points/{\\d+}/post");
     }
 }

--- a/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
@@ -28,7 +28,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**")
-                .excludePathPatterns("/oauth/**")
-                .excludePathPatterns("/points/{\\d+}/post");
+                .excludePathPatterns("/oauth/**");
+//                .excludePathPatterns("/points/{\\d+}/post");
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -98,6 +98,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
+    public PostResponse readByPointId(Long pointId) {
+        Post post = postRepository.getByPointId(pointId);
+        return PostResponse.from(post);
+    }
+
+    @Transactional(readOnly = true)
     public PostsResponse readAllByTripId(Long tripId) {
         if (!tripRepository.existsById(tripId)) {
             throw new TripException(TRIP_NOT_FOUND);

--- a/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
@@ -4,6 +4,7 @@ import static dev.tripdraw.post.exception.PostExceptionType.POST_NOT_FOUND;
 
 import dev.tripdraw.post.exception.PostException;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     default Post getByPostId(Long id) {
         return findById(id)
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+    }
+
+    Optional<Post> findByPointId(Long pointId);
+
+    default Post getByPointId(Long pointId) {
+        return findByPointId(pointId)
                 .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -79,8 +79,7 @@ public class PostController {
             produces = APPLICATION_JSON_VALUE
     )
     public ResponseEntity<PostCreateResponse> create(
-            @Auth
-            LoginUser loginUser,
+            @Auth LoginUser loginUser,
 
             @Parameter(description = "감상 정보를 담은 JSON 객체")
             @Valid
@@ -102,7 +101,6 @@ public class PostController {
     )
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostResponse> read(
-            @Auth LoginUser loginUser,
             @PathVariable Long postId
     ) {
         PostResponse response = postService.read(postId);
@@ -116,7 +114,6 @@ public class PostController {
     )
     @GetMapping("/points/{pointId}/post")
     public ResponseEntity<PostResponse> readByPointId(
-            @Auth LoginUser loginUser,
             @PathVariable Long pointId
     ) {
         PostResponse response = postService.readByPointId(pointId);
@@ -130,7 +127,6 @@ public class PostController {
     )
     @GetMapping("/trips/{tripId}/posts")
     public ResponseEntity<PostsResponse> readAllPostsOfTrip(
-            @Auth LoginUser loginUser,
             @PathVariable Long tripId
     ) {
         PostsResponse response = postService.readAllByTripId(tripId);
@@ -144,7 +140,6 @@ public class PostController {
     )
     @GetMapping("/posts")
     public ResponseEntity<PostsSearchResponse> readAllPosts(
-            @Auth LoginUser loginUser,
             PostSearchRequest postSearchRequest
     ) {
         PostsSearchResponse response = postService.readAll(postSearchRequest);
@@ -161,8 +156,7 @@ public class PostController {
             consumes = MULTIPART_FORM_DATA_VALUE
     )
     public ResponseEntity<Void> update(
-            @Auth
-            LoginUser loginUser,
+            @Auth LoginUser loginUser,
 
             @PathVariable Long postId,
 

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -116,6 +116,7 @@ public class PostController {
     )
     @GetMapping("/points/{pointId}/post")
     public ResponseEntity<PostResponse> readByPointId(
+            @Auth LoginUser loginUser,
             @PathVariable Long pointId
     ) {
         PostResponse response = postService.readByPointId(pointId);

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -109,6 +109,19 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "위치정보로 감상 조회 API", description = "특정한 1개의 감상을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "위치정보로 감상 조회 성공."
+    )
+    @GetMapping("/points/{pointId}/post")
+    public ResponseEntity<PostResponse> readByPointId(
+            @PathVariable Long pointId
+    ) {
+        PostResponse response = postService.readByPointId(pointId);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상을 조회합니다.")
     @ApiResponse(
             responseCode = "200",

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -198,6 +198,29 @@ class PostServiceTest {
     }
 
     @Test
+    void 위치정보_ID로_특정_감상을_조회한다() {
+        // given
+        Post post = postRepository.save(새로운_감상(point, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
+
+        // when
+        PostResponse postResponse = postService.readByPointId(point.id());
+
+        // then
+        assertThat(postResponse).isEqualTo(PostResponse.from(post));
+    }
+
+    @Test
+    void 위치정보_ID로_특정_감상을_조회할_때_존재하지_않는_위치정보_ID이면_예외를_발생시킨다() {
+        // given
+        Long invalidPointId = Long.MIN_VALUE;
+
+        // expect
+        assertThatThrownBy(() -> postService.readByPointId(invalidPointId))
+                .isInstanceOf(PostException.class)
+                .hasMessage(POST_NOT_FOUND.message());
+    }
+
+    @Test
     void 특정_여행의_모든_감상을_조회한다() {
         // given
         Point point1 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 29));

--- a/backend/src/test/java/dev/tripdraw/post/domain/PostRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/domain/PostRepositoryTest.java
@@ -18,6 +18,7 @@ import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -26,8 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -102,6 +101,29 @@ class PostRepositoryTest {
 
         // expect
         assertThatThrownBy(() -> postRepository.getByPostId(invalidPostId))
+                .isInstanceOf(PostException.class)
+                .hasMessage(POST_NOT_FOUND.message());
+    }
+
+    @Test
+    void 위치정보_ID로_감상을_조회한다() {
+        // given
+        Post post = postRepository.save(새로운_감상(point, member.id(), "", trip.id()));
+
+        // when
+        Post foundPost = postRepository.getByPointId(point.id());
+
+        // then
+        assertThat(foundPost).isEqualTo(post);
+    }
+
+    @Test
+    void 위치정보_ID로_감상을_조회할_때_존재하지_않는_경우_예외를_발생시킨다() {
+        // given
+        Long invalidPointId = Long.MIN_VALUE;
+
+        // expect
+        assertThatThrownBy(() -> postRepository.getByPointId(invalidPointId))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.message());
     }

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -288,11 +288,14 @@ class PostControllerTest extends ControllerTest {
 
     @Test
     void 특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외가_발생한다() {
-        // given & expect
+        // given
+        Long invalidPostId = Long.MIN_VALUE;
+
+        // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(accessToken)
-                .when().get("/posts/{postId}", Long.MAX_VALUE)
+                .when().get("/posts/{postId}", invalidPostId)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
     }
@@ -305,6 +308,7 @@ class PostControllerTest extends ControllerTest {
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .auth().preemptive().oauth2(accessToken)
                 .when().get("/points/{pointId}/post", point.id())
                 .then().log().all()
                 .extract();
@@ -322,9 +326,13 @@ class PostControllerTest extends ControllerTest {
 
     @Test
     void 위치정보_ID로_특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외가_발생한다() {
-        // given & expect
+        // given
+        Long invalidPointId = Long.MIN_VALUE;
+
+        // expect
         RestAssured.given().log().all()
-                .when().get("/points/{pointId}/post", Long.MAX_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .when().get("/points/{pointId}/post", invalidPointId)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
     }

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -298,6 +298,38 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
+    void 위치정보_ID로_특정_감상을_조회한다() {
+        // given
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        updateHasPost(List.of(point));
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when().get("/points/{pointId}/post", point.id())
+                .then().log().all()
+                .extract();
+
+        // then
+        PostResponse postResponse = response.as(PostResponse.class);
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softly.assertThat(postResponse)
+                    .usingRecursiveComparison()
+                    .ignoringFieldsOfTypes(LocalDateTime.class)
+                    .isEqualTo(PostResponse.from(post));
+        });
+    }
+
+    @Test
+    void 위치정보_ID로_특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외가_발생한다() {
+        // given & expect
+        RestAssured.given().log().all()
+                .when().get("/points/{pointId}/post", Long.MAX_VALUE)
+                .then().log().all()
+                .statusCode(NOT_FOUND.value());
+    }
+
+    @Test
     void 특정_여행에_대한_모든_감상을_조회한다() {
         // given
         Point point1 = pointRepository.save(새로운_위치정보(trip));


### PR DESCRIPTION
### 📌 관련 이슈

- closed #461 

### 📁 작업 설명

- point Id를 통해 post를 조회하는 api 를 추가했습니다.
- endpoint를 `/points/{pointId}/post` 로 설정했습니다. 혹시 더 나은 방안이 떠오르신다면 추천 부탁드립니다.
- 해당 기능에 인가 처리가 필요하지 않다고 판단했습니다. 기획 상 누구나 다른 사람의 위치정보를 눌러 감상 기록을 조회할 수 있어야 하기 때문입니다. 따라서 AuthConfig의 excludePathPatterns 설정으로 Interceptor가 해당 Url에서 작동하지 않도록 했습니다. 더 나은 방안을 알고 계신다면 알려주세요. 공부하겠습니다!