### PR TITLE
[refactor] 여행, 감상 전체 조회 시 각각 게시글 회원의 닉네임을 함께 반환하도록 수정 (#463)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
@@ -29,6 +29,6 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**")
                 .excludePathPatterns("/oauth/**")
-                .excludePathPatterns("/actuator/**");
+                .excludePathPatterns("/points/{\\d+}/post");
     }
 }

--- a/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
+++ b/backend/src/main/java/dev/tripdraw/common/config/AuthConfig.java
@@ -28,7 +28,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/swagger-ui/**")
                 .excludePathPatterns("/api-docs")
                 .excludePathPatterns("/v3/api-docs/**")
-                .excludePathPatterns("/oauth/**")
-                .excludePathPatterns("/points/{\\d+}/post");
+                .excludePathPatterns("/oauth/**");
+//                .excludePathPatterns("/points/{\\d+}/post");
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -103,6 +103,12 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
+    public PostResponse readByPointId(Long pointId) {
+        Post post = postRepository.getByPointId(pointId);
+        return PostResponse.from(post);
+    }
+
+    @Transactional(readOnly = true)
     public PostsResponse readAllByTripId(Long tripId) {
         if (!tripRepository.existsById(tripId)) {
             throw new TripException(TRIP_NOT_FOUND);

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -40,6 +40,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PostService {
 
     private static final int FIRST_INDEX = 0;
+
     private final PostQueryService postQueryService;
     private final PostRepository postRepository;
     private final TripRepository tripRepository;

--- a/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
@@ -4,6 +4,7 @@ import static dev.tripdraw.post.exception.PostExceptionType.POST_NOT_FOUND;
 
 import dev.tripdraw.post.exception.PostException;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     default Post getByPostId(Long id) {
         return findById(id)
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+    }
+
+    Optional<Post> findByPointId(Long pointId);
+
+    default Post getByPointId(Long pointId) {
+        return findByPointId(pointId)
                 .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostSearchResponse.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 public record PostSearchResponse(
         Long postId,
+        String memberNickname,
         Long tripId,
         String title,
         String address,
@@ -17,9 +18,10 @@ public record PostSearchResponse(
 
     private static final String EMPTY_IMAGE_URL = "";
 
-    public static PostSearchResponse from(Post post) {
+    public static PostSearchResponse from(Post post, String memberNickname) {
         return new PostSearchResponse(
                 post.id(),
+                memberNickname,
                 post.tripId(),
                 post.title(),
                 post.address(),

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -79,8 +79,7 @@ public class PostController {
             produces = APPLICATION_JSON_VALUE
     )
     public ResponseEntity<PostCreateResponse> create(
-            @Auth
-            LoginUser loginUser,
+            @Auth LoginUser loginUser,
 
             @Parameter(description = "감상 정보를 담은 JSON 객체")
             @Valid
@@ -102,7 +101,6 @@ public class PostController {
     )
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostResponse> read(
-            @Auth LoginUser loginUser,
             @PathVariable Long postId
     ) {
         PostResponse response = postService.read(postId);
@@ -116,7 +114,6 @@ public class PostController {
     )
     @GetMapping("/points/{pointId}/post")
     public ResponseEntity<PostResponse> readByPointId(
-            @Auth LoginUser loginUser,
             @PathVariable Long pointId
     ) {
         PostResponse response = postService.readByPointId(pointId);
@@ -130,7 +127,6 @@ public class PostController {
     )
     @GetMapping("/trips/{tripId}/posts")
     public ResponseEntity<PostsResponse> readAllPostsOfTrip(
-            @Auth LoginUser loginUser,
             @PathVariable Long tripId
     ) {
         PostsResponse response = postService.readAllByTripId(tripId);
@@ -144,7 +140,6 @@ public class PostController {
     )
     @GetMapping("/posts")
     public ResponseEntity<PostsSearchResponse> readAllPosts(
-            @Auth LoginUser loginUser,
             PostSearchRequest postSearchRequest
     ) {
         PostsSearchResponse response = postService.readAll(postSearchRequest);
@@ -161,8 +156,7 @@ public class PostController {
             consumes = MULTIPART_FORM_DATA_VALUE
     )
     public ResponseEntity<Void> update(
-            @Auth
-            LoginUser loginUser,
+            @Auth LoginUser loginUser,
 
             @PathVariable Long postId,
 

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -116,6 +116,7 @@ public class PostController {
     )
     @GetMapping("/points/{pointId}/post")
     public ResponseEntity<PostResponse> readByPointId(
+            @Auth LoginUser loginUser,
             @PathVariable Long pointId
     ) {
         PostResponse response = postService.readByPointId(pointId);

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -109,6 +109,19 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "위치정보로 감상 조회 API", description = "특정한 1개의 감상을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "위치정보로 감상 조회 성공."
+    )
+    @GetMapping("/points/{pointId}/post")
+    public ResponseEntity<PostResponse> readByPointId(
+            @PathVariable Long pointId
+    ) {
+        PostResponse response = postService.readByPointId(pointId);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "특정 여행의 모든 감상 조회 API", description = "특정한 1개의 여행에 대해 작성한 모든 감상을 조회합니다.")
     @ApiResponse(
             responseCode = "200",

--- a/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
@@ -10,16 +10,16 @@ import dev.tripdraw.trip.dto.TripCreateResponse;
 import dev.tripdraw.trip.dto.TripResponse;
 import dev.tripdraw.trip.dto.TripSearchConditions;
 import dev.tripdraw.trip.dto.TripSearchRequest;
+import dev.tripdraw.trip.dto.TripSearchResponse;
 import dev.tripdraw.trip.dto.TripUpdateRequest;
 import dev.tripdraw.trip.dto.TripsSearchResponse;
 import dev.tripdraw.trip.dto.TripsSearchResponseOfMember;
 import dev.tripdraw.trip.query.TripPaging;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional
@@ -61,10 +61,14 @@ public class TripService {
 
         List<Trip> trips = tripQueryService.readAllByQueryConditions(condition, tripPaging);
 
-        if (tripPaging.hasNextPage(trips.size())) {
-            return TripsSearchResponse.of(trips.subList(FIRST_INDEX, tripPaging.limit()), true);
+        List<TripSearchResponse> responses = trips.stream()
+                .map(trip -> TripSearchResponse.from(trip, memberRepository.getNicknameById(trip.memberId())))
+                .toList();
+
+        if (tripPaging.hasNextPage(responses.size())) {
+            return TripsSearchResponse.of(responses.subList(FIRST_INDEX, tripPaging.limit()), true);
         }
-        return TripsSearchResponse.of(trips, false);
+        return TripsSearchResponse.of(responses, false);
     }
 
     public void updateTripById(LoginUser loginUser, Long tripId, TripUpdateRequest tripUpdateRequest) {

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchResponse.java
@@ -9,6 +9,9 @@ public record TripSearchResponse(
         @Schema(description = "여행 Id", example = "1")
         Long tripId,
 
+        @Schema(description = "회원 닉네임", example = "통후추")
+        String memberNickname,
+
         @Schema(description = "여행명", example = "통후추의 여행")
         String name,
 
@@ -27,9 +30,10 @@ public record TripSearchResponse(
 
     private static final String EMPTY_IMAGE_URL = "";
 
-    public static TripSearchResponse from(Trip trip) {
+    public static TripSearchResponse from(Trip trip, String memberNickname) {
         return new TripSearchResponse(
                 trip.id(),
+                memberNickname,
                 trip.nameValue(),
                 Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL),
                 Objects.requireNonNullElse(trip.routeImageUrl(), EMPTY_IMAGE_URL),

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripsSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripsSearchResponse.java
@@ -1,6 +1,5 @@
 package dev.tripdraw.trip.dto;
 
-import dev.tripdraw.trip.domain.Trip;
 import java.util.List;
 
 public record TripsSearchResponse(
@@ -8,10 +7,7 @@ public record TripsSearchResponse(
         boolean hasNextPage
 ) {
 
-    public static TripsSearchResponse of(List<Trip> trips, boolean hasNextPage) {
-        List<TripSearchResponse> tripsSearchResponse = trips.stream()
-                .map(TripSearchResponse::from)
-                .toList();
-        return new TripsSearchResponse(tripsSearchResponse, hasNextPage);
+    public static TripsSearchResponse of(List<TripSearchResponse> tripSearchResponses, boolean hasNextPage) {
+        return new TripsSearchResponse(tripSearchResponses, hasNextPage);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -198,6 +198,29 @@ class PostServiceTest {
     }
 
     @Test
+    void 위치정보_ID로_특정_감상을_조회한다() {
+        // given
+        Post post = postRepository.save(새로운_감상(point, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
+
+        // when
+        PostResponse postResponse = postService.readByPointId(point.id());
+
+        // then
+        assertThat(postResponse).isEqualTo(PostResponse.from(post));
+    }
+
+    @Test
+    void 위치정보_ID로_특정_감상을_조회할_때_존재하지_않는_위치정보_ID이면_예외를_발생시킨다() {
+        // given
+        Long invalidPointId = Long.MIN_VALUE;
+
+        // expect
+        assertThatThrownBy(() -> postService.readByPointId(invalidPointId))
+                .isInstanceOf(PostException.class)
+                .hasMessage(POST_NOT_FOUND.message());
+    }
+
+    @Test
     void 특정_여행의_모든_감상을_조회한다() {
         // given
         Point point1 = pointRepository.save(새로운_위치정보(2023, 7, 12, 15, 29));

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -241,7 +241,8 @@ class PostServiceTest {
 
         // then
         assertThat(postsSearchResponse.posts())
-                .contains(PostSearchResponse.from(jejuJulyPost), PostSearchResponse.from(jejuMayPost));
+                .contains(PostSearchResponse.from(jejuJulyPost, member.nickname()),
+                        PostSearchResponse.from(jejuMayPost, member.nickname()));
     }
 
     @Test
@@ -264,7 +265,8 @@ class PostServiceTest {
 
         // then
         assertThat(postsSearchResponse.posts())
-                .containsExactly(PostSearchResponse.from(seoulJulyPost), PostSearchResponse.from(jejuJulyPost));
+                .containsExactly(PostSearchResponse.from(seoulJulyPost, member.nickname()),
+                        PostSearchResponse.from(jejuJulyPost, member.nickname()));
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/post/domain/PostRepositoryTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/domain/PostRepositoryTest.java
@@ -18,6 +18,7 @@ import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.domain.PointRepository;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -26,8 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.util.List;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -102,6 +101,29 @@ class PostRepositoryTest {
 
         // expect
         assertThatThrownBy(() -> postRepository.getByPostId(invalidPostId))
+                .isInstanceOf(PostException.class)
+                .hasMessage(POST_NOT_FOUND.message());
+    }
+
+    @Test
+    void 위치정보_ID로_감상을_조회한다() {
+        // given
+        Post post = postRepository.save(새로운_감상(point, member.id(), "", trip.id()));
+
+        // when
+        Post foundPost = postRepository.getByPointId(point.id());
+
+        // then
+        assertThat(foundPost).isEqualTo(post);
+    }
+
+    @Test
+    void 위치정보_ID로_감상을_조회할_때_존재하지_않는_경우_예외를_발생시킨다() {
+        // given
+        Long invalidPointId = Long.MIN_VALUE;
+
+        // expect
+        assertThatThrownBy(() -> postRepository.getByPointId(invalidPointId))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.message());
     }

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -289,11 +289,14 @@ class PostControllerTest extends ControllerTest {
 
     @Test
     void 특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외가_발생한다() {
-        // given & expect
+        // given
+        Long invalidPostId = Long.MIN_VALUE;
+
+        // expect
         RestAssured.given().log().all()
                 .contentType(APPLICATION_JSON_VALUE)
                 .auth().preemptive().oauth2(accessToken)
-                .when().get("/posts/{postId}", Long.MAX_VALUE)
+                .when().get("/posts/{postId}", invalidPostId)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
     }
@@ -306,6 +309,7 @@ class PostControllerTest extends ControllerTest {
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .auth().preemptive().oauth2(accessToken)
                 .when().get("/points/{pointId}/post", point.id())
                 .then().log().all()
                 .extract();
@@ -323,9 +327,13 @@ class PostControllerTest extends ControllerTest {
 
     @Test
     void 위치정보_ID로_특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외가_발생한다() {
-        // given & expect
+        // given
+        Long invalidPointId = Long.MIN_VALUE;
+
+        // expect
         RestAssured.given().log().all()
-                .when().get("/points/{pointId}/post", Long.MAX_VALUE)
+                .auth().preemptive().oauth2(accessToken)
+                .when().get("/points/{pointId}/post", invalidPointId)
                 .then().log().all()
                 .statusCode(NOT_FOUND.value());
     }

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -27,6 +27,7 @@ import dev.tripdraw.post.dto.PostAndPointCreateRequest;
 import dev.tripdraw.post.dto.PostCreateResponse;
 import dev.tripdraw.post.dto.PostRequest;
 import dev.tripdraw.post.dto.PostResponse;
+import dev.tripdraw.post.dto.PostSearchResponse;
 import dev.tripdraw.post.dto.PostUpdateRequest;
 import dev.tripdraw.post.dto.PostsResponse;
 import dev.tripdraw.post.dto.PostsSearchResponse;
@@ -458,7 +459,10 @@ class PostControllerTest extends ControllerTest {
             softly.assertThat(postsSearchResponse.posts())
                     .usingRecursiveComparison()
                     .ignoringFieldsOfTypes(LocalDateTime.class)
-                    .isEqualTo(List.of(PostResponse.from(jejuAugustPost), PostResponse.from(jejuJulyPost)));
+                    .isEqualTo(List.of(
+                            PostSearchResponse.from(jejuAugustPost, member.nickname()),
+                            PostSearchResponse.from(jejuJulyPost, member.nickname())
+                    ));
         });
     }
 

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -299,6 +299,38 @@ class PostControllerTest extends ControllerTest {
     }
 
     @Test
+    void 위치정보_ID로_특정_감상을_조회한다() {
+        // given
+        Post post = postRepository.save(새로운_감상(point, member.id()));
+        updateHasPost(List.of(point));
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when().get("/points/{pointId}/post", point.id())
+                .then().log().all()
+                .extract();
+
+        // then
+        PostResponse postResponse = response.as(PostResponse.class);
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(OK.value());
+            softly.assertThat(postResponse)
+                    .usingRecursiveComparison()
+                    .ignoringFieldsOfTypes(LocalDateTime.class)
+                    .isEqualTo(PostResponse.from(post));
+        });
+    }
+
+    @Test
+    void 위치정보_ID로_특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외가_발생한다() {
+        // given & expect
+        RestAssured.given().log().all()
+                .when().get("/points/{pointId}/post", Long.MAX_VALUE)
+                .then().log().all()
+                .statusCode(NOT_FOUND.value());
+    }
+
+    @Test
     void 특정_여행에_대한_모든_감상을_조회한다() {
         // given
         Point point1 = pointRepository.save(새로운_위치정보(trip));

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
@@ -24,6 +24,7 @@ import dev.tripdraw.trip.domain.TripRepository;
 import dev.tripdraw.trip.dto.TripCreateResponse;
 import dev.tripdraw.trip.dto.TripResponse;
 import dev.tripdraw.trip.dto.TripSearchRequest;
+import dev.tripdraw.trip.dto.TripSearchResponse;
 import dev.tripdraw.trip.dto.TripUpdateRequest;
 import dev.tripdraw.trip.dto.TripsSearchResponse;
 import dev.tripdraw.trip.dto.TripsSearchResponseOfMember;
@@ -64,14 +65,14 @@ class TripServiceTest {
     private PostRepository postRepository;
 
     private Trip trip;
-    private Point point;
+    private Member member;
     private LoginUser loginUser;
 
     @BeforeEach
     void setUp() {
-        Member member = memberRepository.save(사용자());
+        member = memberRepository.save(사용자());
         trip = tripRepository.save(새로운_여행(member));
-        point = pointRepository.save(새로운_위치정보(trip));
+        Point point = pointRepository.save(새로운_위치정보(trip));
         trip.add(point);
         loginUser = new LoginUser(member.id());
         postRepository.save(새로운_감상(point, member.id(), "", trip.id()));
@@ -120,7 +121,7 @@ class TripServiceTest {
         assertThat(tripsSearchResponse)
                 .usingRecursiveComparison()
                 .ignoringFieldsOfTypes(LocalDateTime.class)
-                .isEqualTo(TripsSearchResponse.of(List.of(trip), false));
+                .isEqualTo(TripsSearchResponse.of(List.of(TripSearchResponse.from(trip, member.nickname())), false));
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/trip/presentation/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/presentation/TripControllerTest.java
@@ -65,13 +65,14 @@ class TripControllerTest extends ControllerTest {
     private Trip huchuTrip;
     private String reoToken;
     private Trip reoTrip;
+    private Member reo;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
 
         Member huchu = memberRepository.save(새로운_사용자("통후추"));
-        Member reo = memberRepository.save(새로운_사용자("리오"));
+        reo = memberRepository.save(새로운_사용자("리오"));
         huchuToken = jwtTokenProvider.generateAccessToken(huchu.id().toString());
         reoToken = jwtTokenProvider.generateAccessToken(reo.id().toString());
         huchuTrip = tripRepository.save(새로운_여행(huchu));
@@ -208,6 +209,9 @@ class TripControllerTest extends ControllerTest {
             softly.assertThat(tripsSearchResponse.trips())
                     .extracting(TripSearchResponse::tripId)
                     .containsExactly(리오_서울_2023_1_1_일);
+            softly.assertThat(tripsSearchResponse.trips())
+                    .extracting(TripSearchResponse::memberNickname)
+                    .containsExactly(reo.nickname());
         });
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- closed #463 

### 📁 작업 설명

- 여행 전체 조회 시 memberNickname 을 함께 반환하도록 수정
- 감상 전체 조회 시 memberNickname 을 함께 반환하도록 수정

### 참고

Trip, Post 모두 memberId를 필드로 갖고 있습니다. 따라서 MemberRepository에서 memberId로 nickname을 조회해서 반환 dto에 포함하도록 변경했습니다.

이것이 바뀐 코드입니다.
```java
@Transactional(readOnly = true)
public TripsSearchResponse readAll(TripSearchRequest tripSearchRequest) {
    TripSearchConditions condition = tripSearchRequest.toTripSearchConditions();
    TripPaging tripPaging = tripSearchRequest.toTripPaging();

    List<Trip> trips = tripQueryService.readAllByQueryConditions(condition, tripPaging);

    List<TripSearchResponse> responses = trips.stream()
            .map(trip -> TripSearchResponse.from(trip, memberRepository.getNicknameById(trip.memberId())))
            .toList();

    if (tripPaging.hasNextPage(responses.size())) {
        return TripsSearchResponse.of(responses.subList(FIRST_INDEX, tripPaging.limit()), true);
    }
    return TripsSearchResponse.of(responses, false);
}
```

List<TripSearchResponse>를 생성하는 과정에서 여행의 memberId로 Nickname을 조회해서 TripSearchResponse를 만듭니다.

위와 같은 구현 방식은 빠르고 간단하게 구현할 수 있어 좋습니다. 하지만, `여행의 개수만큼 닉네임 조회 query가 실행`될 겁니다. 안드로이드 측에서 이 기능을 빠르게 원해서 `선 구현 후 리팩터링`하겠습니다.

만약 리팩터링을 한다면, tripQueryService 에서 여행 정보를 조회해올 때 회원 Table, 여행 Table  join을 통해 회원 정보도 함께 조회하려고 합니다. join을 통해 쿼리 개수를 줄일 수 있을 것입니다.

위 내용은 감상에서도 동일합니다.
