### PR TITLE
[feat] 다이얼로그 태블릿 대응 사이즈 조정 (#466)

### DIFF
--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/DialogUtil.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/DialogUtil.kt
@@ -31,7 +31,6 @@ class DialogUtil(
         super.onViewCreated(view, savedInstanceState)
 
         isCancelable = true
-        setLayout()
         setMessage()
         setConfirmText()
         setConfirmTextColor()
@@ -41,19 +40,7 @@ class DialogUtil(
 
     override fun onStart() {
         super.onStart()
-        setLayout()
-    }
-
-    private fun setLayout() {
-        requireNotNull(dialog).apply {
-            requireNotNull(window).apply {
-                setLayout(
-                    (resources.displayMetrics.widthPixels * DIALOG_WINDOW_SIZE).toInt(),
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
-                setBackgroundDrawableResource(R.color.td_white)
-            }
-        }
+        ResponsiveUiDialogSizeAdjuster().adjustSize(dialog, resources)
     }
 
     private fun setMessage() {
@@ -106,7 +93,6 @@ class DialogUtil(
     }
 
     companion object {
-        private const val DIALOG_WINDOW_SIZE = 0.85
         const val DELETE_CHECK = 0
         const val SAVE_CHECK = 1
         const val LOGOUT_CHECK = 2

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/ResponsiveUiDialogSizeAdjuster.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/ResponsiveUiDialogSizeAdjuster.kt
@@ -1,0 +1,53 @@
+package com.teamtripdraw.android.ui.common.dialog
+
+import android.app.Dialog
+import android.content.res.Resources
+import android.view.ViewGroup
+import com.teamtripdraw.android.R
+import kotlin.math.roundToInt
+
+class ResponsiveUiDialogSizeAdjuster {
+
+    fun adjustSize(dialog: Dialog?, resources: Resources) {
+        dialog ?: return
+        when (isOverPhoneSize(resources)) {
+            true -> adjustTabletDialogSize(dialog, resources)
+            false -> adjustPhoneDialogSize(dialog, resources)
+        }
+    }
+
+    private fun isOverPhoneSize(resources: Resources): Boolean =
+        getDeviceDPValue(resources) >= DEVICE_TYPE_BOUNDARY
+
+    private fun getDeviceDPValue(resources: Resources): Int =
+        (resources.displayMetrics.widthPixels / resources.displayMetrics.density).roundToInt()
+
+    private fun adjustPhoneDialogSize(dialog: Dialog, resources: Resources) {
+        dialog.window?.apply {
+            setLayout(
+                (resources.displayMetrics.widthPixels * PHONE_DIALOG_WIDTH_RATIO).toInt(),
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+            setBackgroundDrawableResource(R.color.td_white)
+        }
+    }
+
+    private fun adjustTabletDialogSize(dialog: Dialog, resources: Resources) {
+        dialog.window?.apply {
+            setLayout(
+                dPToPixel(TABLET_DIALOG_WIDTH_DP, resources),
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+            setBackgroundDrawableResource(R.color.td_white)
+        }
+    }
+
+    private fun dPToPixel(dp: Int, resources: Resources): Int =
+        (dp * resources.displayMetrics.density).roundToInt()
+
+    companion object {
+        private const val PHONE_DIALOG_WIDTH_RATIO = 0.85
+        private const val DEVICE_TYPE_BOUNDARY = 600
+        private const val TABLET_DIALOG_WIDTH_DP = 400
+    }
+}

--- a/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialog.kt
+++ b/android/app/src/main/java/com/teamtripdraw/android/ui/common/dialog/SetTripTitleDialog.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import com.teamtripdraw.android.R
 import com.teamtripdraw.android.databinding.FragmentTripTitleDialogBinding
 import com.teamtripdraw.android.support.framework.presentation.event.EventObserver
 import com.teamtripdraw.android.support.framework.presentation.getParcelableCompat
@@ -54,19 +53,7 @@ class SetTripTitleDialog : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        setLayout()
-    }
-
-    private fun setLayout() {
-        requireNotNull(dialog).apply {
-            requireNotNull(window).apply {
-                setLayout(
-                    (resources.displayMetrics.widthPixels * DIALOG_WINDOW_SIZE).toInt(),
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
-                setBackgroundDrawableResource(R.color.td_white)
-            }
-        }
+        ResponsiveUiDialogSizeAdjuster().adjustSize(dialog, resources)
     }
 
     private fun initCompletedEventObserve() {
@@ -106,7 +93,6 @@ class SetTripTitleDialog : DialogFragment() {
     }
 
     companion object {
-        private const val DIALOG_WINDOW_SIZE = 0.85
         private const val TRIP_ID_KEY = "TRIP_ID_KEY"
         private const val SET_TITLE_SITUATION_KEY = "SET_TITLE_SITUATION_KEY"
 


### PR DESCRIPTION
### 📌 관련 이슈

- closed #466 

### 📁 작업 설명

- 다이얼로스 태블릿 사이즈 조정 (자세한사항 이슈 참고)

### 📸 작업화면
태블릿
<img width="309" alt="image" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/54737136/f198d8e9-9aca-4ccd-a2e7-aab58fb568f8">

폰
<img width="370" alt="image" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/54737136/95777f2a-65ea-4eb5-9f3f-7dc1ce4904fd">


