### PR TITLE
[fix] Paging 처리 시 NullPointerException 예외 처리 (#473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@ render.experimental.xml
 
 # private files
 /backend/src/main/resources/application-dev.yml
+/backend/src/main/resources/application-dev1.yml
+/backend/src/main/resources/application-dev2.yml
 /backend/src/main/resources/application-prod.yml
+/backend/src/main/resources/application-prod1.yml
+/backend/src/main/resources/application-prod2.yml
 
 # Keystore files
 *.jks

--- a/backend/src/main/java/dev/tripdraw/admin/application/AdminService.java
+++ b/backend/src/main/java/dev/tripdraw/admin/application/AdminService.java
@@ -6,7 +6,7 @@ import dev.tripdraw.admin.dto.AdminTripResponse;
 import dev.tripdraw.admin.dto.AdminTripsResponse;
 import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.post.domain.PostRepository;
-import dev.tripdraw.post.dto.PostSearchPaging;
+import dev.tripdraw.post.dto.PostPaging;
 import dev.tripdraw.post.query.PostCustomRepository;
 import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.domain.TripRepository;
@@ -48,8 +48,8 @@ public class AdminService {
 
     @Transactional(readOnly = true)
     public AdminPostsResponse readPosts(Long lastViewId, Integer limit) {
-        PostSearchPaging postSearchPaging = new PostSearchPaging(lastViewId, limit);
-        List<Post> posts = postCustomRepository.findAll(postSearchPaging);
+        PostPaging postPaging = new PostPaging(lastViewId, limit);
+        List<Post> posts = postCustomRepository.findAll(postPaging);
         if (limit < posts.size()) {
             return AdminPostsResponse.of(posts.subList(0, limit), true);
         }

--- a/backend/src/main/java/dev/tripdraw/post/application/PostQueryService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostQueryService.java
@@ -1,13 +1,12 @@
 package dev.tripdraw.post.application;
 
 import dev.tripdraw.post.domain.Post;
+import dev.tripdraw.post.dto.PostPaging;
 import dev.tripdraw.post.dto.PostSearchConditions;
-import dev.tripdraw.post.dto.PostSearchPaging;
 import dev.tripdraw.post.query.PostCustomRepository;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 public class PostQueryService {
@@ -19,7 +18,7 @@ public class PostQueryService {
     }
 
     @Transactional(readOnly = true)
-    public List<Post> findAllByConditions(PostSearchConditions conditions, PostSearchPaging paging) {
+    public List<Post> readAllByConditions(PostSearchConditions conditions, PostPaging paging) {
         return postCustomRepository.findAllByConditions(conditions, paging);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/application/PostService.java
+++ b/backend/src/main/java/dev/tripdraw/post/application/PostService.java
@@ -13,10 +13,10 @@ import dev.tripdraw.post.domain.PostCreateEvent;
 import dev.tripdraw.post.domain.PostRepository;
 import dev.tripdraw.post.dto.PostAndPointCreateRequest;
 import dev.tripdraw.post.dto.PostCreateResponse;
+import dev.tripdraw.post.dto.PostPaging;
 import dev.tripdraw.post.dto.PostRequest;
 import dev.tripdraw.post.dto.PostResponse;
 import dev.tripdraw.post.dto.PostSearchConditions;
-import dev.tripdraw.post.dto.PostSearchPaging;
 import dev.tripdraw.post.dto.PostSearchRequest;
 import dev.tripdraw.post.dto.PostSearchResponse;
 import dev.tripdraw.post.dto.PostUpdateRequest;
@@ -142,23 +142,19 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostsSearchResponse readAll(PostSearchRequest postSearchRequest) {
-        PostSearchConditions postSearchConditions = postSearchRequest.toPostSearchConditions();
-        PostSearchPaging postSearchPaging = postSearchRequest.toPostSearchPaging();
+        PostSearchConditions conditions = postSearchRequest.toPostSearchConditions();
+        PostPaging postPaging = postSearchRequest.toPostPaging();
 
-        List<Post> posts = postQueryService.findAllByConditions(postSearchConditions, postSearchPaging);
+        List<Post> posts = postQueryService.readAllByConditions(conditions, postPaging);
 
         List<PostSearchResponse> responses = posts.stream()
                 .map(post -> PostSearchResponse.from(post, memberRepository.getNicknameById(post.memberId())))
                 .toList();
 
-        if (hasNextPage(postSearchPaging.limit(), posts)) {
-            return PostsSearchResponse.of(responses.subList(FIRST_INDEX, postSearchPaging.limit()), true);
+        if (postPaging.hasNextPage(responses.size())) {
+            return PostsSearchResponse.of(responses.subList(FIRST_INDEX, postPaging.limit()), true);
         }
         return PostsSearchResponse.of(responses, false);
-    }
-
-    private boolean hasNextPage(int limit, List<Post> posts) {
-        return limit < posts.size();
     }
 }
 

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostPaging.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostPaging.java
@@ -1,0 +1,29 @@
+package dev.tripdraw.post.dto;
+
+import java.util.Objects;
+
+public record PostPaging(Long lastViewedId, Integer limit) {
+
+    private static final int DEFAULT_LIMIT = 20;
+    private static final int LIMIT_MAXIMUM = 100;
+
+    public PostPaging(Long lastViewedId, Integer limit) {
+        this.lastViewedId = lastViewedId;
+        this.limit = preprocess(limit);
+    }
+
+    private int preprocess(Integer limit) {
+        if (Objects.isNull(limit)) {
+            return DEFAULT_LIMIT;
+        }
+        return ceil(limit);
+    }
+
+    private int ceil(Integer limit) {
+        return Math.min(limit, LIMIT_MAXIMUM);
+    }
+
+    public boolean hasNextPage(int size) {
+        return limit < size;
+    }
+}

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostSearchPaging.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostSearchPaging.java
@@ -1,4 +1,0 @@
-package dev.tripdraw.post.dto;
-
-public record PostSearchPaging(Long lastViewedId, Integer limit) {
-}

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostSearchRequest.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostSearchRequest.java
@@ -28,7 +28,7 @@ public record PostSearchRequest(
                 .build();
     }
 
-    public PostSearchPaging toPostSearchPaging() {
-        return new PostSearchPaging(lastViewedId, limit);
+    public PostPaging toPostPaging() {
+        return new PostPaging(lastViewedId, limit);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/query/PostCustomRepository.java
+++ b/backend/src/main/java/dev/tripdraw/post/query/PostCustomRepository.java
@@ -1,13 +1,13 @@
 package dev.tripdraw.post.query;
 
 import dev.tripdraw.post.domain.Post;
+import dev.tripdraw.post.dto.PostPaging;
 import dev.tripdraw.post.dto.PostSearchConditions;
-import dev.tripdraw.post.dto.PostSearchPaging;
 import java.util.List;
 
 public interface PostCustomRepository {
 
-    List<Post> findAllByConditions(PostSearchConditions conditions, PostSearchPaging paging);
+    List<Post> findAllByConditions(PostSearchConditions conditions, PostPaging paging);
 
-    List<Post> findAll(PostSearchPaging paging);
+    List<Post> findAll(PostPaging paging);
 }

--- a/backend/src/main/java/dev/tripdraw/post/query/PostCustomRepositoryImpl.java
+++ b/backend/src/main/java/dev/tripdraw/post/query/PostCustomRepositoryImpl.java
@@ -5,8 +5,8 @@ import static dev.tripdraw.post.domain.QPost.post;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dev.tripdraw.post.domain.Post;
+import dev.tripdraw.post.dto.PostPaging;
 import dev.tripdraw.post.dto.PostSearchConditions;
-import dev.tripdraw.post.dto.PostSearchPaging;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Post> findAllByConditions(PostSearchConditions conditions, PostSearchPaging paging) {
+    public List<Post> findAllByConditions(PostSearchConditions conditions, PostPaging paging) {
         // TODO: 2023/09/16 연령대, 성별 추가
         return jpaQueryFactory.selectFrom(post)
                 .leftJoin(post.point).fetchJoin()
@@ -85,7 +85,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public List<Post> findAll(PostSearchPaging paging) {
+    public List<Post> findAll(PostPaging paging) {
         return jpaQueryFactory.selectFrom(post)
                 .leftJoin(post.point).fetchJoin()
                 .where(postIdLt(paging.lastViewedId()))

--- a/backend/src/main/java/dev/tripdraw/trip/application/TripQueryService.java
+++ b/backend/src/main/java/dev/tripdraw/trip/application/TripQueryService.java
@@ -4,11 +4,10 @@ import dev.tripdraw.trip.domain.Trip;
 import dev.tripdraw.trip.dto.TripSearchConditions;
 import dev.tripdraw.trip.query.TripCustomRepository;
 import dev.tripdraw.trip.query.TripPaging;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional
@@ -18,7 +17,7 @@ public class TripQueryService {
     private final TripCustomRepository tripCustomRepository;
 
     @Transactional(readOnly = true)
-    public List<Trip> readAllByQueryConditions(TripSearchConditions tripSearchConditions, TripPaging tripPaging) {
+    public List<Trip> readAllByConditions(TripSearchConditions tripSearchConditions, TripPaging tripPaging) {
         return tripCustomRepository.findAllByConditions(tripSearchConditions, tripPaging);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
@@ -55,10 +55,10 @@ public class TripService {
 
     @Transactional(readOnly = true)
     public TripsSearchResponse readAll(TripSearchRequest tripSearchRequest) {
-        TripSearchConditions condition = tripSearchRequest.toTripSearchConditions();
+        TripSearchConditions conditions = tripSearchRequest.toTripSearchConditions();
         TripPaging tripPaging = tripSearchRequest.toTripPaging();
 
-        List<Trip> trips = tripQueryService.readAllByQueryConditions(condition, tripPaging);
+        List<Trip> trips = tripQueryService.readAllByConditions(conditions, tripPaging);
 
         List<TripSearchResponse> responses = trips.stream()
                 .map(trip -> TripSearchResponse.from(trip, memberRepository.getNicknameById(trip.memberId())))

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchPaging.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchPaging.java
@@ -1,9 +1,0 @@
-package dev.tripdraw.trip.dto;
-
-import dev.tripdraw.trip.query.TripPaging;
-
-public record TripSearchPaging(Long lastViewedId, Integer limit) {
-    public TripPaging toTripPaging() {
-        return new TripPaging(lastViewedId, limit);
-    }
-}

--- a/backend/src/main/java/dev/tripdraw/trip/query/TripPaging.java
+++ b/backend/src/main/java/dev/tripdraw/trip/query/TripPaging.java
@@ -1,11 +1,22 @@
 package dev.tripdraw.trip.query;
 
+import java.util.Objects;
+
 public record TripPaging(Long lastViewedId, Integer limit) {
+
+    private static final int DEFAULT_LIMIT = 20;
     private static final int LIMIT_MAXIMUM = 100;
 
     public TripPaging(Long lastViewedId, Integer limit) {
         this.lastViewedId = lastViewedId;
-        this.limit = ceil(limit);
+        this.limit = preprocess(limit);
+    }
+
+    private int preprocess(Integer limit) {
+        if (Objects.isNull(limit)) {
+            return DEFAULT_LIMIT;
+        }
+        return ceil(limit);
     }
 
     private int ceil(Integer limit) {

--- a/backend/src/test/java/dev/tripdraw/common/domain/TripPagingTest.java
+++ b/backend/src/test/java/dev/tripdraw/common/domain/TripPagingTest.java
@@ -27,7 +27,7 @@ class TripPagingTest {
     }
 
     @Test
-    void limit이_100을_넘기면_100으로_조정된다() {
+    void limit이_최대값을_넘기면_최대값으로_조정된다() {
         // given
         int limit = 101;
 
@@ -36,5 +36,17 @@ class TripPagingTest {
 
         // then
         assertThat(tripPaging.limit()).isEqualTo(100);
+    }
+
+    @Test
+    void limit이_null이면_기본값으로_조정된다() {
+        // given
+        Integer limit = null;
+
+        // when
+        TripPaging tripPaging = new TripPaging(1L, limit);
+
+        // then
+        assertThat(tripPaging.limit()).isEqualTo(20);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/post/domain/PostCustomRepositoryImplTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/domain/PostCustomRepositoryImplTest.java
@@ -9,8 +9,8 @@ import dev.tripdraw.common.config.JpaConfig;
 import dev.tripdraw.common.config.QueryDslConfig;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
+import dev.tripdraw.post.dto.PostPaging;
 import dev.tripdraw.post.dto.PostSearchConditions;
-import dev.tripdraw.post.dto.PostSearchPaging;
 import dev.tripdraw.post.query.PostCustomRepository;
 import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.domain.PointRepository;
@@ -58,7 +58,7 @@ class PostCustomRepositoryImplTest {
         PostSearchConditions conditions = PostSearchConditions.builder()
                 .months(Set.of(7))
                 .build();
-        PostSearchPaging paging = new PostSearchPaging(null, 10);
+        PostPaging paging = new PostPaging(null, 10);
 
         // when
         List<Post> posts = postCustomRepository.findAllByConditions(conditions, paging);
@@ -75,10 +75,10 @@ class PostCustomRepositoryImplTest {
             Point point = pointRepository.save(새로운_위치정보(LocalDateTime.now()));
             postRepository.save(새로운_감상(point, member.id(), "주소 " + i));
         }
-        PostSearchPaging postSearchPaging = new PostSearchPaging(null, 3);
+        PostPaging postPaging = new PostPaging(null, 3);
 
         // when
-        List<Post> posts = postCustomRepository.findAll(postSearchPaging);
+        List<Post> posts = postCustomRepository.findAll(postPaging);
 
         // then
         assertThat(posts)

--- a/backend/src/test/java/dev/tripdraw/post/dto/PostPagingTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/dto/PostPagingTest.java
@@ -1,0 +1,51 @@
+package dev.tripdraw.post.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PostPagingTest {
+
+    @ParameterizedTest
+    @CsvSource({"19, false", "20, false", "21, true"})
+    void 다음_페이지가_있는지_확인한다(int size, boolean expected) {
+        // given
+        PostPaging postPaging = new PostPaging(1L, 20);
+
+        // when
+        boolean actual = postPaging.hasNextPage(size);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void limit이_최대값을_넘기면_최대값으로_조정된다() {
+        // given
+        int limit = 101;
+
+        // when
+        PostPaging postPaging = new PostPaging(1L, limit);
+
+        // then
+        assertThat(postPaging.limit()).isEqualTo(100);
+    }
+
+    @Test
+    void limit이_null이면_기본값으로_조정된다() {
+        // given
+        Integer limit = null;
+
+        // when
+        PostPaging postPaging = new PostPaging(1L, limit);
+
+        // then
+        assertThat(postPaging.limit()).isEqualTo(20);
+    }
+}

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripQueryServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripQueryServiceTest.java
@@ -41,7 +41,7 @@ class TripQueryServiceTest {
                 .willReturn(new ArrayList<>());
 
         // when
-        List<Trip> trips = tripQueryService.readAllByQueryConditions(tripSearchConditions, tripPaging);
+        List<Trip> trips = tripQueryService.readAllByConditions(tripSearchConditions, tripPaging);
 
         // then
         assertThat(trips).isEmpty();


### PR DESCRIPTION
### 📌 관련 이슈

- closed #473 

### 📁 작업 설명

- 서버 nginx 에서 QueryString 처리하지 못하는 문제 해결 (feat. 리오)
- Paging 에서 limit이 null 인 경우 default 값 설정
- 감상과 여행 Paging 관련 컨벤션 맞추기
- gitignore 에 private file 추가

### 참고
limit이 null 인 경우, 예외를 던지기보다는 default 값으로 설정하는 것이 나을 것이라 판단했습니다.
default 값은 지금 팀 컨벤션인 `limit = 20` 으로 설정했습니다.