### PR TITLE
[feat] 감상 상세 조회 시 member ID, 닉네임도 반환하도록 변경 (#481)

### DIFF
--- a/backend/src/main/java/dev/tripdraw/post/domain/Post.java
+++ b/backend/src/main/java/dev/tripdraw/post/domain/Post.java
@@ -1,10 +1,12 @@
 package dev.tripdraw.post.domain;
 
 import static dev.tripdraw.post.exception.PostExceptionType.NOT_AUTHORIZED_TO_POST;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import dev.tripdraw.common.entity.BaseEntity;
+import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.post.exception.PostException;
 import dev.tripdraw.trip.domain.Point;
 import jakarta.persistence.Column;
@@ -12,6 +14,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -45,29 +48,31 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "point_id")
     private Point point;
 
-    private Long memberId;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     private String postImageUrl;
 
     private String routeImageUrl;
 
-    public Post(String title, Point point, String address, String writing, Long memberId, Long tripId) {
-        this(null, title, point, address, writing, memberId, tripId);
+    public Post(String title, Point point, String address, String writing, Member member, Long tripId) {
+        this(null, title, point, address, writing, member, tripId);
     }
 
-    public Post(Long id, String title, Point point, String address, String writing, Long memberId, Long tripId) {
+    public Post(Long id, String title, Point point, String address, String writing, Member member, Long tripId) {
         point.registerPost();
         this.id = id;
         this.title = title;
         this.point = point;
         this.address = address;
         this.writing = writing;
-        this.memberId = memberId;
+        this.member = member;
         this.tripId = tripId;
     }
 
     public void validateAuthorization(Long memberId) {
-        if (!this.memberId.equals(memberId)) {
+        if (!this.member.id().equals(memberId)) {
             throw new PostException(NOT_AUTHORIZED_TO_POST);
         }
     }

--- a/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
+++ b/backend/src/main/java/dev/tripdraw/post/domain/PostRepository.java
@@ -28,7 +28,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     }
 
     @Modifying
-    @Query("DELETE FROM Post p WHERE p.memberId = :memberId")
+    @Query("DELETE FROM Post p WHERE p.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);
 
     @Modifying

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostAndPointCreateRequest.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostAndPointCreateRequest.java
@@ -3,6 +3,7 @@ package dev.tripdraw.post.dto;
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.domain.Trip;
@@ -52,7 +53,7 @@ public record PostAndPointCreateRequest(
         return new Point(latitude, longitude, recordedAt, trip);
     }
 
-    public Post toPost(Long memberId, Point point) {
-        return new Post(title, point, address, writing, memberId, tripId);
+    public Post toPost(Member member, Point point) {
+        return new Post(title, point, address, writing, member, tripId);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostRequest.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostRequest.java
@@ -1,5 +1,6 @@
 package dev.tripdraw.post.dto;
 
+import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.post.domain.Post;
 import dev.tripdraw.trip.domain.Point;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,7 +30,7 @@ public record PostRequest(
         String writing
 ) {
 
-    public Post toPost(Long memberId, Point point) {
-        return new Post(title, point, address, writing, memberId, tripId);
+    public Post toPost(Member member, Point point) {
+        return new Post(title, point, address, writing, member, tripId);
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostResponse.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostResponse.java
@@ -12,6 +12,12 @@ public record PostResponse(
         @Schema(description = "감상이 속하는 여행의 Id", example = "1")
         Long tripId,
 
+        @Schema(description = "나의 감상 확인 flag", example = "true")
+        boolean isMine,
+
+        @Schema(description = "작성자 닉네임", example = "통후추")
+        String authorNickname,
+
         @Schema(description = "제목", example = "우도의 바닷가")
         String title,
 
@@ -33,10 +39,12 @@ public record PostResponse(
 
     private static final String EMPTY_IMAGE_URL = "";
 
-    public static PostResponse from(Post post) {
+    public static PostResponse from(Post post, Long loginUserId) {
         return new PostResponse(
                 post.id(),
                 post.tripId(),
+                post.member().id().equals(loginUserId),
+                post.member().nickname(),
                 post.title(),
                 post.address(),
                 post.writing(),

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostSearchResponse.java
@@ -6,8 +6,9 @@ import java.util.Objects;
 
 public record PostSearchResponse(
         Long postId,
-        String memberNickname,
         Long tripId,
+        boolean isMine,
+        String authorNickname,
         String title,
         String address,
         String writing,
@@ -18,11 +19,12 @@ public record PostSearchResponse(
 
     private static final String EMPTY_IMAGE_URL = "";
 
-    public static PostSearchResponse from(Post post, String memberNickname) {
+    public static PostSearchResponse from(Post post, Long loginUserId) {
         return new PostSearchResponse(
                 post.id(),
-                memberNickname,
                 post.tripId(),
+                post.member().id().equals(loginUserId),
+                post.member().nickname(),
                 post.title(),
                 post.address(),
                 post.writing(),

--- a/backend/src/main/java/dev/tripdraw/post/dto/PostsResponse.java
+++ b/backend/src/main/java/dev/tripdraw/post/dto/PostsResponse.java
@@ -8,9 +8,9 @@ public record PostsResponse(
         @Schema(description = "감상 목록")
         List<PostResponse> posts
 ) {
-    public static PostsResponse from(List<Post> posts) {
+    public static PostsResponse from(List<Post> posts, Long loginUserId) {
         return new PostsResponse(posts.stream()
-                .map(PostResponse::from)
+                .map(post -> PostResponse.from(post, loginUserId))
                 .toList());
     }
 }

--- a/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
+++ b/backend/src/main/java/dev/tripdraw/post/presentation/PostController.java
@@ -101,9 +101,10 @@ public class PostController {
     )
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostResponse> read(
+            @Auth LoginUser loginUser,
             @PathVariable Long postId
     ) {
-        PostResponse response = postService.read(postId);
+        PostResponse response = postService.read(loginUser, postId);
         return ResponseEntity.ok(response);
     }
 
@@ -114,9 +115,10 @@ public class PostController {
     )
     @GetMapping("/points/{pointId}/post")
     public ResponseEntity<PostResponse> readByPointId(
+            @Auth LoginUser loginUser,
             @PathVariable Long pointId
     ) {
-        PostResponse response = postService.readByPointId(pointId);
+        PostResponse response = postService.readByPointId(loginUser, pointId);
         return ResponseEntity.ok(response);
     }
 
@@ -127,9 +129,10 @@ public class PostController {
     )
     @GetMapping("/trips/{tripId}/posts")
     public ResponseEntity<PostsResponse> readAllPostsOfTrip(
+            @Auth LoginUser loginUser,
             @PathVariable Long tripId
     ) {
-        PostsResponse response = postService.readAllByTripId(tripId);
+        PostsResponse response = postService.readAllByTripId(loginUser, tripId);
         return ResponseEntity.ok(response);
     }
 
@@ -140,9 +143,10 @@ public class PostController {
     )
     @GetMapping("/posts")
     public ResponseEntity<PostsSearchResponse> readAllPosts(
+            @Auth LoginUser loginUser,
             PostSearchRequest postSearchRequest
     ) {
-        PostsSearchResponse response = postService.readAll(postSearchRequest);
+        PostsSearchResponse response = postService.readAll(loginUser, postSearchRequest);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
@@ -40,9 +40,9 @@ public class TripService {
     }
 
     @Transactional(readOnly = true)
-    public TripResponse readTripById(Long id) {
+    public TripResponse readTripById(LoginUser loginUser, Long id) {
         Trip trip = tripRepository.getById(id);
-        return TripResponse.from(trip);
+        return TripResponse.from(trip, loginUser.memberId());
     }
 
     @Transactional(readOnly = true)
@@ -59,7 +59,7 @@ public class TripService {
         List<Trip> trips = tripQueryService.readAllByConditions(conditions, tripPaging);
 
         List<TripSearchResponse> responses = trips.stream()
-                .map(trip -> TripSearchResponse.from(trip, trip.member().nickname()))
+                .map(trip -> TripSearchResponse.from(trip, trip.member().id()))
                 .toList();
 
         if (tripPaging.hasNextPage(responses.size())) {

--- a/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
+++ b/backend/src/main/java/dev/tripdraw/trip/application/TripService.java
@@ -34,9 +34,7 @@ public class TripService {
     private final ApplicationEventPublisher publisher;
 
     public TripCreateResponse create(LoginUser loginUser) {
-        Long memberId = loginUser.memberId();
-
-        Trip trip = Trip.of(memberId, memberRepository.getNicknameById(memberId));
+        Trip trip = Trip.of(memberRepository.getById(loginUser.memberId()));
         Trip savedTrip = tripRepository.save(trip);
         return TripCreateResponse.from(savedTrip);
     }
@@ -61,7 +59,7 @@ public class TripService {
         List<Trip> trips = tripQueryService.readAllByConditions(conditions, tripPaging);
 
         List<TripSearchResponse> responses = trips.stream()
-                .map(trip -> TripSearchResponse.from(trip, memberRepository.getNicknameById(trip.memberId())))
+                .map(trip -> TripSearchResponse.from(trip, trip.member().nickname()))
                 .toList();
 
         if (tripPaging.hasNextPage(responses.size())) {

--- a/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
+++ b/backend/src/main/java/dev/tripdraw/trip/domain/TripRepository.java
@@ -1,22 +1,21 @@
 package dev.tripdraw.trip.domain;
 
+import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
+
 import dev.tripdraw.trip.exception.TripException;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
-
-import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
 
     List<Trip> findAllByMemberId(Long memberId);
 
     @Modifying
-    @Query("DELETE FROM Trip t WHERE t.memberId = :memberId")
+    @Query("DELETE FROM Trip t WHERE t.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);
 
     default Trip getById(Long id) {
@@ -32,6 +31,6 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
                 .orElseThrow(() -> new TripException(TRIP_NOT_FOUND));
     }
 
-    @Query("SELECT t.id FROM Trip t WHERE t.memberId = :memberId")
+    @Query("SELECT t.id FROM Trip t WHERE t.member.id = :memberId")
     List<Long> findAllTripIdsByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripResponse.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripResponse.java
@@ -10,6 +10,12 @@ public record TripResponse(
         @Schema(description = "여행 Id", example = "1")
         Long tripId,
 
+        @Schema(description = "나의 여행 확인 flag", example = "true")
+        boolean isMine,
+
+        @Schema(description = "작성자 닉네임", example = "통후추")
+        String authorNickname,
+
         @Schema(description = "여행명", example = "통후추의 여행")
         String name,
 
@@ -28,9 +34,11 @@ public record TripResponse(
 
     private static final String EMPTY_IMAGE_URL = "";
 
-    public static TripResponse from(Trip trip) {
+    public static TripResponse from(Trip trip, Long loginUserId) {
         return new TripResponse(
                 trip.id(),
+                trip.member().id().equals(loginUserId),
+                trip.member().nickname(),
                 trip.nameValue(),
                 generateRoute(trip),
                 trip.status(),

--- a/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchResponse.java
+++ b/backend/src/main/java/dev/tripdraw/trip/dto/TripSearchResponse.java
@@ -9,8 +9,11 @@ public record TripSearchResponse(
         @Schema(description = "여행 Id", example = "1")
         Long tripId,
 
-        @Schema(description = "회원 닉네임", example = "통후추")
-        String memberNickname,
+        @Schema(description = "나의 여행 확인 flag", example = "true")
+        boolean isMine,
+
+        @Schema(description = "작성자 닉네임", example = "통후추")
+        String authorNickname,
 
         @Schema(description = "여행명", example = "통후추의 여행")
         String name,
@@ -30,10 +33,11 @@ public record TripSearchResponse(
 
     private static final String EMPTY_IMAGE_URL = "";
 
-    public static TripSearchResponse from(Trip trip, String memberNickname) {
+    public static TripSearchResponse from(Trip trip, Long loginUserId) {
         return new TripSearchResponse(
                 trip.id(),
-                memberNickname,
+                trip.member().id().equals(loginUserId),
+                trip.member().nickname(),
                 trip.nameValue(),
                 Objects.requireNonNullElse(trip.imageUrl(), EMPTY_IMAGE_URL),
                 Objects.requireNonNullElse(trip.routeImageUrl(), EMPTY_IMAGE_URL),

--- a/backend/src/main/java/dev/tripdraw/trip/presentation/TripController.java
+++ b/backend/src/main/java/dev/tripdraw/trip/presentation/TripController.java
@@ -53,8 +53,8 @@ public class TripController {
             description = "나의 여행 조회 성공."
     )
     @GetMapping("/{tripId}")
-    public ResponseEntity<TripResponse> readById(@PathVariable Long tripId) {
-        TripResponse response = tripService.readTripById(tripId);
+    public ResponseEntity<TripResponse> readById(@Auth LoginUser loginUser, @PathVariable Long tripId) {
+        TripResponse response = tripService.readTripById(loginUser, tripId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -85,7 +85,7 @@ class PostServiceTest {
     @BeforeEach
     void setUp() {
         member = memberRepository.save(사용자());
-        trip = tripRepository.save(Trip.of(member.id(), member.nickname()));
+        trip = tripRepository.save(Trip.of(member));
         point = pointRepository.save(새로운_위치정보(trip));
     }
 

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -8,7 +8,6 @@ import static dev.tripdraw.test.fixture.MemberFixture.다른_사용자;
 import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
 import static dev.tripdraw.test.fixture.PostFixture.새로운_감상;
-import static dev.tripdraw.trip.exception.TripExceptionType.NOT_AUTHORIZED_TO_TRIP;
 import static dev.tripdraw.trip.exception.TripExceptionType.POINT_NOT_FOUND;
 import static dev.tripdraw.trip.exception.TripExceptionType.TRIP_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,18 +103,6 @@ class PostServiceTest {
     }
 
     @Test
-    void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
-        // given
-        LoginUser invalidUser = new LoginUser(Long.MIN_VALUE);
-        PostAndPointCreateRequest postAndPointCreateRequest = 현재_위치_감상_생성_요청(trip.id());
-
-        // expect
-        assertThatThrownBy(() -> postService.addAtCurrentPoint(invalidUser, postAndPointCreateRequest, null))
-                .isInstanceOf(TripException.class)
-                .hasMessage(NOT_AUTHORIZED_TO_TRIP.message());
-    }
-
-    @Test
     void 현재_위치에_대한_감상을_생성할_때_존재하지_않는_여행의_ID이면_예외를_발생시킨다() {
         // given
         LoginUser loginUser = new LoginUser(member.id());
@@ -139,18 +126,6 @@ class PostServiceTest {
 
         // then
         assertThat(postCreateResponse.postId()).isNotNull();
-    }
-
-    @Test
-    void 사용자가_선택한_위치에_대한_감상을_생성할_때_존재하지_않는_사용자_닉네임이면_예외를_발생시킨다() {
-        // given
-        PostRequest postRequest = 감상_생성_요청(trip.id(), point.id());
-        LoginUser invalidUser = new LoginUser(Long.MIN_VALUE);
-
-        // expect
-        assertThatThrownBy(() -> postService.addAtExistingLocation(invalidUser, postRequest, null))
-                .isInstanceOf(TripException.class)
-                .hasMessage(NOT_AUTHORIZED_TO_TRIP.message());
     }
 
     @Test

--- a/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/application/PostServiceTest.java
@@ -81,12 +81,14 @@ class PostServiceTest {
     private Member member;
     private Trip trip;
     private Point point;
+    private LoginUser loginUser;
 
     @BeforeEach
     void setUp() {
         member = memberRepository.save(사용자());
         trip = tripRepository.save(Trip.of(member));
         point = pointRepository.save(새로운_위치정보(trip));
+        loginUser = new LoginUser(member.id());
     }
 
     @Test
@@ -158,16 +160,16 @@ class PostServiceTest {
         Post post = postRepository.save(새로운_감상(point, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
 
         // when
-        PostResponse postResponse = postService.read(post.id());
+        PostResponse postResponse = postService.read(loginUser, post.id());
 
         // then
-        assertThat(postResponse).isEqualTo(PostResponse.from(post));
+        assertThat(postResponse).isEqualTo(PostResponse.from(post, loginUser.memberId()));
     }
 
     @Test
     void 특정_감상을_조회할_때_존재하지_않는_감상_ID이면_예외를_발생시킨다() {
         // expect
-        assertThatThrownBy(() -> postService.read(Long.MIN_VALUE))
+        assertThatThrownBy(() -> postService.read(loginUser, Long.MIN_VALUE))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.message());
     }
@@ -178,10 +180,10 @@ class PostServiceTest {
         Post post = postRepository.save(새로운_감상(point, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
 
         // when
-        PostResponse postResponse = postService.readByPointId(point.id());
+        PostResponse postResponse = postService.readByPointId(loginUser, point.id());
 
         // then
-        assertThat(postResponse).isEqualTo(PostResponse.from(post));
+        assertThat(postResponse).isEqualTo(PostResponse.from(post, loginUser.memberId()));
     }
 
     @Test
@@ -190,7 +192,7 @@ class PostServiceTest {
         Long invalidPointId = Long.MIN_VALUE;
 
         // expect
-        assertThatThrownBy(() -> postService.readByPointId(invalidPointId))
+        assertThatThrownBy(() -> postService.readByPointId(loginUser, invalidPointId))
                 .isInstanceOf(PostException.class)
                 .hasMessage(POST_NOT_FOUND.message());
     }
@@ -204,17 +206,19 @@ class PostServiceTest {
         Post post2 = postRepository.save(새로운_감상(point2, member.id(), "제주특별자치도 제주시 애월읍", trip.id()));
 
         // when
-        PostsResponse postsResponse = postService.readAllByTripId(trip.id());
+        PostsResponse postsResponse = postService.readAllByTripId(loginUser, trip.id());
 
         // then
-        assertThat(postsResponse.posts())
-                .containsExactly(PostResponse.from(post2), PostResponse.from(post1));
+        assertThat(postsResponse.posts()).containsExactly(
+                PostResponse.from(post2, loginUser.memberId()),
+                PostResponse.from(post1, loginUser.memberId())
+        );
     }
 
     @Test
     void 특정_여행의_모든_감상을_조회할_때_존재하지_않는_여행_ID이면_예외가_발생한다() {
         // expect
-        assertThatThrownBy(() -> postService.readAllByTripId(Long.MIN_VALUE))
+        assertThatThrownBy(() -> postService.readAllByTripId(loginUser, Long.MIN_VALUE))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.message());
     }
@@ -235,12 +239,13 @@ class PostServiceTest {
                 .build();
 
         // when
-        PostsSearchResponse postsSearchResponse = postService.readAll(postSearchRequest);
+        PostsSearchResponse postsSearchResponse = postService.readAll(loginUser, postSearchRequest);
 
         // then
-        assertThat(postsSearchResponse.posts())
-                .contains(PostSearchResponse.from(jejuJulyPost, member.nickname()),
-                        PostSearchResponse.from(jejuMayPost, member.nickname()));
+        assertThat(postsSearchResponse.posts()).contains(
+                PostSearchResponse.from(jejuJulyPost, member.id()),
+                PostSearchResponse.from(jejuMayPost, member.id())
+        );
     }
 
     @Test
@@ -259,12 +264,13 @@ class PostServiceTest {
                 .build();
 
         // when
-        PostsSearchResponse postsSearchResponse = postService.readAll(postSearchRequest);
+        PostsSearchResponse postsSearchResponse = postService.readAll(loginUser, postSearchRequest);
 
         // then
-        assertThat(postsSearchResponse.posts())
-                .containsExactly(PostSearchResponse.from(seoulJulyPost, member.nickname()),
-                        PostSearchResponse.from(jejuJulyPost, member.nickname()));
+        assertThat(postsSearchResponse.posts()).containsExactly(
+                PostSearchResponse.from(seoulJulyPost, member.id()),
+                PostSearchResponse.from(jejuJulyPost, member.id())
+        );
     }
 
     @Test
@@ -336,7 +342,7 @@ class PostServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(point.hasPost()).isFalse();
-            softly.assertThatThrownBy(() -> postService.read(post.id()))
+            softly.assertThatThrownBy(() -> postService.read(loginUser, post.id()))
                     .isInstanceOf(PostException.class)
                     .hasMessage(POST_NOT_FOUND.message());
         });

--- a/backend/src/test/java/dev/tripdraw/post/domain/PostTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/domain/PostTest.java
@@ -1,6 +1,7 @@
 package dev.tripdraw.post.domain;
 
 import static dev.tripdraw.post.exception.PostExceptionType.NOT_AUTHORIZED_TO_POST;
+import static dev.tripdraw.test.fixture.MemberFixture.사용자;
 import static dev.tripdraw.test.fixture.PointFixture.새로운_위치정보;
 import static dev.tripdraw.test.fixture.PointFixture.위치정보;
 import static dev.tripdraw.trip.exception.TripExceptionType.POINT_ALREADY_HAS_POST;
@@ -8,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.post.exception.PostException;
 import dev.tripdraw.trip.domain.Point;
 import dev.tripdraw.trip.exception.TripException;
@@ -24,7 +26,7 @@ class PostTest {
     void 감상에_저장된_위치정보의_시간을_가져온다() {
         // given
         LocalDateTime recordedAt = LocalDateTime.now();
-        Post post = new Post("제목", 새로운_위치정보(recordedAt), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        Post post = new Post("제목", 새로운_위치정보(recordedAt), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // expect
         assertThat(post.pointRecordedAt()).isEqualTo(recordedAt);
@@ -33,18 +35,17 @@ class PostTest {
     @Test
     void 사용자의_감상인지_확인한다() {
         // given
-        Long memberId = 1L;
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", memberId, 1L);
+        Member member = 사용자();
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", member, 1L);
 
         // expect
-        assertThatNoException().isThrownBy(() -> post.validateAuthorization(memberId));
+        assertThatNoException().isThrownBy(() -> post.validateAuthorization(member.id()));
     }
 
     @Test
     void 사용자의_감상이_아니라면_예외가_발생한다() {
         // given
-        Long memberId = 1L;
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", memberId, 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // expect
         assertThatThrownBy(() -> post.validateAuthorization(Long.MAX_VALUE))
@@ -58,7 +59,7 @@ class PostTest {
         Point point = 위치정보();
 
         // when
-        new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // then
         assertThat(point.hasPost()).isTrue();
@@ -71,7 +72,7 @@ class PostTest {
         point.registerPost();
 
         // expect
-        assertThatThrownBy(() -> new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", 1L, 1L))
+        assertThatThrownBy(() -> new Post("제목", point, "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L))
                 .isInstanceOf(TripException.class)
                 .hasMessage(POINT_ALREADY_HAS_POST.message());
     }
@@ -79,7 +80,7 @@ class PostTest {
     @Test
     void 감상의_제목을_수정한다() {
         // given
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // when
         post.changeTitle("바뀐 제목");
@@ -91,7 +92,7 @@ class PostTest {
     @Test
     void 감상의_내용을_수정한다() {
         // given
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // when
         post.changeWriting("내일은 바람이 많네요.");
@@ -103,7 +104,7 @@ class PostTest {
     @Test
     void 감상_사진_URL을_변경한다() {
         // given
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // when
         post.changePostImageUrl("/통후추셀카.jpg");
@@ -115,7 +116,7 @@ class PostTest {
     @Test
     void 경로_이미지_URL을_변경한다() {
         // given
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
 
         // when
         post.changeRouteImageUrl("/통후추여행경로.png");
@@ -127,7 +128,7 @@ class PostTest {
     @Test
     void 감상의_사진_URL을_제거한다() {
         // given
-        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 1L, 1L);
+        Post post = new Post("제목", 위치정보(), "위치", "오늘은 날씨가 좋네요.", 사용자(), 1L);
         post.changePostImageUrl("example.url");
 
         // when

--- a/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/post/presentation/PostControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import dev.tripdraw.auth.application.JwtTokenProvider;
+import dev.tripdraw.common.auth.LoginUser;
 import dev.tripdraw.draw.application.RouteImageGenerator;
 import dev.tripdraw.member.domain.Member;
 import dev.tripdraw.member.domain.MemberRepository;
@@ -80,6 +81,7 @@ class PostControllerTest extends ControllerTest {
     private Trip trip;
     private Point point;
     private String accessToken;
+    private LoginUser loginUser;
 
     @BeforeEach
     public void setUp() {
@@ -88,6 +90,7 @@ class PostControllerTest extends ControllerTest {
         trip = tripRepository.save(새로운_여행(member));
         point = pointRepository.save(새로운_위치정보(trip));
         accessToken = jwtTokenProvider.generateAccessToken(member.id().toString());
+        loginUser = new LoginUser(member.id());
     }
 
     @Test
@@ -279,7 +282,7 @@ class PostControllerTest extends ControllerTest {
             softly.assertThat(postResponse)
                     .usingRecursiveComparison()
                     .ignoringFieldsOfTypes(LocalDateTime.class)
-                    .isEqualTo(PostResponse.from(post));
+                    .isEqualTo(PostResponse.from(post, loginUser.memberId()));
         });
     }
 
@@ -321,7 +324,7 @@ class PostControllerTest extends ControllerTest {
             softly.assertThat(postResponse)
                     .usingRecursiveComparison()
                     .ignoringFieldsOfTypes(LocalDateTime.class)
-                    .isEqualTo(PostResponse.from(post));
+                    .isEqualTo(PostResponse.from(post, loginUser.memberId()));
         });
     }
 
@@ -362,7 +365,10 @@ class PostControllerTest extends ControllerTest {
             softly.assertThat(postsResponse.posts())
                     .usingRecursiveComparison()
                     .ignoringFieldsOfTypes(LocalDateTime.class)
-                    .isEqualTo(List.of(PostResponse.from(post2), PostResponse.from(post1)));
+                    .isEqualTo(List.of(
+                            PostResponse.from(post2, loginUser.memberId()),
+                            PostResponse.from(post1, loginUser.memberId())
+                    ));
         });
     }
 
@@ -500,8 +506,8 @@ class PostControllerTest extends ControllerTest {
                     .usingRecursiveComparison()
                     .ignoringFieldsOfTypes(LocalDateTime.class)
                     .isEqualTo(List.of(
-                            PostSearchResponse.from(jejuAugustPost, member.nickname()),
-                            PostSearchResponse.from(jejuJulyPost, member.nickname())
+                            PostSearchResponse.from(jejuAugustPost, member.id()),
+                            PostSearchResponse.from(jejuJulyPost, member.id())
                     ));
         });
     }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/MemberFixture.java
@@ -11,6 +11,10 @@ public class MemberFixture {
         return new Member(1L, "통후추", OAUTH_아이디 + "통후추", OauthType.KAKAO);
     }
 
+    public static Member 사용자(Long memberId) {
+        return new Member(memberId, "통후추", OAUTH_아이디 + "통후추", OauthType.KAKAO);
+    }
+
     public static Member 다른_사용자() {
         return new Member("순후추", OAUTH_아이디 + "순후추", OauthType.KAKAO);
     }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/PostFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/PostFixture.java
@@ -9,18 +9,18 @@ import dev.tripdraw.trip.domain.Point;
 public class PostFixture {
 
     public static Post 감상() {
-        return new Post(1L, "감상 제목", 위치정보(), "주소", "감상", 사용자().id(), 1L);
+        return new Post(1L, "감상 제목", 위치정보(), "주소", "감상", 사용자(), 1L);
     }
 
     public static Post 새로운_감상(Point point, Long memberId) {
-        return new Post("감상 제목", point, "주소", "감상", memberId, 1L);
+        return new Post("감상 제목", point, "주소", "감상", 사용자(memberId), 1L);
     }
 
     public static Post 새로운_감상(Point point, Long memberId, String address) {
-        return new Post("감상 제목", point, address, "감상", memberId, 1L);
+        return new Post("감상 제목", point, address, "감상", 사용자(memberId), 1L);
     }
 
     public static Post 새로운_감상(Point point, Long memberId, String address, Long tripId) {
-        return new Post("감상 제목", point, address, "감상", memberId, tripId);
+        return new Post("감상 제목", point, address, "감상", 사용자(memberId), tripId);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/test/fixture/TripFixture.java
+++ b/backend/src/test/java/dev/tripdraw/test/fixture/TripFixture.java
@@ -11,14 +11,14 @@ import dev.tripdraw.trip.domain.TripStatus;
 public class TripFixture {
 
     public static Trip 여행() {
-        return new Trip(1L, TripName.from("통후추"), 사용자().id(), TripStatus.ONGOING, "", "");
+        return new Trip(1L, TripName.from("통후추"), 사용자(), TripStatus.ONGOING, "", "");
     }
 
     public static Trip 새로운_여행(Member member) {
-        return new Trip(TripName.from(member.nickname()), member.id());
+        return new Trip(TripName.from(member.nickname()), member);
     }
 
     public static Trip 새로운_여행(Member member, String tripName) {
-        return new Trip(new TripName(tripName), member.id());
+        return new Trip(new TripName(tripName), member);
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/application/TripServiceTest.java
@@ -90,10 +90,10 @@ class TripServiceTest {
     @Test
     void 여행을_ID로_조회한다() {
         // when
-        TripResponse tripResponse = tripService.readTripById(trip.id());
+        TripResponse tripResponse = tripService.readTripById(loginUser, trip.id());
 
         // expect
-        assertThat(tripResponse).isEqualTo(TripResponse.from(trip));
+        assertThat(tripResponse).isEqualTo(TripResponse.from(trip, loginUser.memberId()));
     }
 
     @Test
@@ -121,7 +121,7 @@ class TripServiceTest {
         assertThat(tripsSearchResponse)
                 .usingRecursiveComparison()
                 .ignoringFieldsOfTypes(LocalDateTime.class)
-                .isEqualTo(TripsSearchResponse.of(List.of(TripSearchResponse.from(trip, member.nickname())), false));
+                .isEqualTo(TripsSearchResponse.of(List.of(TripSearchResponse.from(trip, member.id())), false));
     }
 
     @Test
@@ -146,7 +146,7 @@ class TripServiceTest {
         tripService.delete(loginUser, trip.id());
 
         // then
-        assertThatThrownBy(() -> tripService.readTripById(trip.id()))
+        assertThatThrownBy(() -> tripService.readTripById(loginUser, trip.id()))
                 .isInstanceOf(TripException.class)
                 .hasMessage(TRIP_NOT_FOUND.message());
     }

--- a/backend/src/test/java/dev/tripdraw/trip/domain/PointTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/domain/PointTest.java
@@ -46,7 +46,7 @@ class PointTest {
         // given
         Point point = new Point(3.14, 5.25, LocalDateTime.now());
         Member member = new Member("통후추", "kakaoId", KAKAO);
-        Trip trip = Trip.of(member.id(), member.nickname());
+        Trip trip = Trip.of(member);
 
         // when
         point.setTrip(trip);

--- a/backend/src/test/java/dev/tripdraw/trip/dto/TripSearchResponseOfMemberTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/dto/TripSearchResponseOfMemberTest.java
@@ -20,7 +20,7 @@ class TripSearchResponseOfMemberTest {
         // given
         Member member = 사용자();
         TripName tripName = TripName.from("통후추의 여행");
-        Trip trip = new Trip(1L, tripName, member.id(), ONGOING, null, null);
+        Trip trip = new Trip(1L, tripName, member, ONGOING, null, null);
 
         // when
         TripSearchResponseOfMember response = TripSearchResponseOfMember.from(trip);
@@ -28,6 +28,6 @@ class TripSearchResponseOfMemberTest {
         // then
         assertThat(response)
                 .usingRecursiveComparison()
-                .isEqualTo(TripSearchResponseOfMember.from(new Trip(1L, tripName, member.id(), ONGOING, "", "")));
+                .isEqualTo(TripSearchResponseOfMember.from(new Trip(1L, tripName, member, ONGOING, "", "")));
     }
 }

--- a/backend/src/test/java/dev/tripdraw/trip/presentation/TripControllerTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/presentation/TripControllerTest.java
@@ -65,13 +65,14 @@ class TripControllerTest extends ControllerTest {
     private Trip huchuTrip;
     private String reoToken;
     private Trip reoTrip;
+    private Member huchu;
     private Member reo;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
 
-        Member huchu = memberRepository.save(새로운_사용자("통후추"));
+        huchu = memberRepository.save(새로운_사용자("통후추"));
         reo = memberRepository.save(새로운_사용자("리오"));
         huchuToken = jwtTokenProvider.generateAccessToken(huchu.id().toString());
         reoToken = jwtTokenProvider.generateAccessToken(reo.id().toString());
@@ -109,7 +110,7 @@ class TripControllerTest extends ControllerTest {
         TripResponse tripResponse = response.as(TripResponse.class);
         assertSoftly(softly -> {
             softly.assertThat(response.statusCode()).isEqualTo(OK.value());
-            softly.assertThat(tripResponse).isEqualTo(TripResponse.from(huchuTrip));
+            softly.assertThat(tripResponse).isEqualTo(TripResponse.from(huchuTrip, huchu.id()));
         });
     }
 
@@ -210,7 +211,7 @@ class TripControllerTest extends ControllerTest {
                     .extracting(TripSearchResponse::tripId)
                     .containsExactly(리오_서울_2023_1_1_일);
             softly.assertThat(tripsSearchResponse.trips())
-                    .extracting(TripSearchResponse::memberNickname)
+                    .extracting(TripSearchResponse::authorNickname)
                     .containsExactly(reo.nickname());
         });
     }

--- a/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
@@ -443,7 +443,7 @@ class TripCustomRepositoryImplTest {
         }
 
         private Trip jeju_2023_2_1_Wed() {
-            Trip trip = Trip.of(member.id(), member.nickname());
+            Trip trip = Trip.of(member);
             Point point = PointFixture.새로운_위치정보(2023, 2, 1, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
@@ -452,7 +452,7 @@ class TripCustomRepositoryImplTest {
         }
 
         private Trip seoul_2023_1_1_Sun() {
-            Trip trip = Trip.of(member.id(), member.nickname());
+            Trip trip = Trip.of(member);
             Point point = PointFixture.새로운_위치정보(2023, 1, 1, 10, 1);
             trip.add(point);
             tripRepository.save(trip);
@@ -461,7 +461,7 @@ class TripCustomRepositoryImplTest {
         }
 
         private Trip jeju_2023_1_1_Sun() {
-            Trip trip = Trip.of(member.id(), member.nickname());
+            Trip trip = Trip.of(member);
             Point point = PointFixture.새로운_위치정보(2023, 1, 1, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
@@ -470,7 +470,7 @@ class TripCustomRepositoryImplTest {
         }
 
         private Trip seoul_2022_1_2_Sun() {
-            Trip trip = Trip.of(member.id(), member.nickname());
+            Trip trip = Trip.of(member);
             Point point = PointFixture.새로운_위치정보(2022, 1, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
@@ -479,7 +479,7 @@ class TripCustomRepositoryImplTest {
         }
 
         private Trip yangyang_2021_3_2_Tue() {
-            Trip trip = Trip.of(member.id(), member.nickname());
+            Trip trip = Trip.of(member);
             Point point = PointFixture.새로운_위치정보(2021, 3, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
@@ -488,7 +488,7 @@ class TripCustomRepositoryImplTest {
         }
 
         private Trip emptyPostTrip() {
-            Trip trip = Trip.of(member.id(), member.nickname());
+            Trip trip = Trip.of(member);
             Point point = PointFixture.새로운_위치정보(2021, 3, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);

--- a/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
+++ b/backend/src/test/java/dev/tripdraw/trip/query/TripCustomRepositoryImplTest.java
@@ -447,7 +447,7 @@ class TripCustomRepositoryImplTest {
             Point point = PointFixture.새로운_위치정보(2023, 2, 1, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
-            postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member.id(), trip.id()));
+            postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member, trip.id()));
             return trip;
         }
 
@@ -456,7 +456,7 @@ class TripCustomRepositoryImplTest {
             Point point = PointFixture.새로운_위치정보(2023, 1, 1, 10, 1);
             trip.add(point);
             tripRepository.save(trip);
-            postRepository.save(new Post("", point, "서울특별시 송파구 신천동", "", member.id(), trip.id()));
+            postRepository.save(new Post("", point, "서울특별시 송파구 신천동", "", member, trip.id()));
             return trip;
         }
 
@@ -465,7 +465,7 @@ class TripCustomRepositoryImplTest {
             Point point = PointFixture.새로운_위치정보(2023, 1, 1, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
-            postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member.id(), trip.id()));
+            postRepository.save(new Post("", point, "제주특별자치도 제주시 애월읍", "", member, trip.id()));
             return trip;
         }
 
@@ -474,7 +474,7 @@ class TripCustomRepositoryImplTest {
             Point point = PointFixture.새로운_위치정보(2022, 1, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
-            postRepository.save(new Post("", point, "서울특별시 송파구 방이동", "", member.id(), trip.id()));
+            postRepository.save(new Post("", point, "서울특별시 송파구 방이동", "", member, trip.id()));
             return trip;
         }
 
@@ -483,7 +483,7 @@ class TripCustomRepositoryImplTest {
             Point point = PointFixture.새로운_위치정보(2021, 3, 2, 1, 1);
             trip.add(point);
             tripRepository.save(trip);
-            postRepository.save(new Post("", point, "강원도 양양군", "", member.id(), trip.id()));
+            postRepository.save(new Post("", point, "강원도 양양군", "", member, trip.id()));
             return trip;
         }
 


### PR DESCRIPTION
### 📌 관련 이슈

- closed #481 

### 📁 작업 설명

- Trip과 Post가 Member를 참조하도록 변경하고, dto가 자기가 작성한 글인지, 작성자의 닉네임을 반환하도록 했습니다.