### PR TITLE
[feat] 감상 작성 / 태블릿 화면에서 이미지 미리보기 크기 조절 (#506)

### DIFF
--- a/android/app/src/main/res/layout/activity_post_writing.xml
+++ b/android/app/src/main/res/layout/activity_post_writing.xml
@@ -135,8 +135,8 @@
 
         <ImageView
             android:id="@+id/iv_post_writing_image_thumbnail"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
+            android:layout_width="@dimen/post_wiring_activity_image_view_width"
+            android:layout_height="@dimen/post_wiring_activity_image_view_width"
             android:layout_marginEnd="8dp"
             app:layout_constraintBottom_toBottomOf="@+id/et_writing"
             app:layout_constraintEnd_toEndOf="@+id/et_writing"
@@ -146,8 +146,8 @@
 
         <ImageView
             android:id="@+id/btn_post_writing_image_delete"
-            android:layout_width="16dp"
-            android:layout_height="16dp"
+            android:layout_width="@dimen/post_wiring_activity_image_delete_view_width"
+            android:layout_height="@dimen/post_wiring_activity_image_delete_view_width"
             android:onClick="@{() -> postWritingViewModel.deleteImage()}"
             android:src="@drawable/ic_image_delete"
             app:layout_constraintBottom_toTopOf="@id/iv_post_writing_image_thumbnail"

--- a/android/app/src/main/res/values-w600dp/dimens.xml
+++ b/android/app/src/main/res/values-w600dp/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--    PostWritingActivity    -->
+    <dimen name="post_wiring_activity_image_view_width">100dp</dimen>
+    <dimen name="post_wiring_activity_image_delete_view_width">24dp</dimen>
+
+</resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -4,4 +4,8 @@
     <dimen name="toolbar_default">56dp</dimen>
     <dimen name="button_height_default">52dp</dimen>
 
+    <!--    PostWritingActivity    -->
+    <dimen name="post_wiring_activity_image_view_width">56dp</dimen>
+    <dimen name="post_wiring_activity_image_delete_view_width">16dp</dimen>
+
 </resources>


### PR DESCRIPTION
### 📌 관련 이슈
- closed #506

### 📁 작업 설명
- 태블릿 화면에서 이미지 미리보기 크기 조절

### 📸 작업화면

### 핸드폰
<img width="200" alt="image" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/69189793/f7876a4c-a73e-4c7e-b3a0-53c5afef67c9">


### 태블릿
<img width="200" alt="image" src="https://github.com/woowacourse-teams/2023-trip-draw/assets/69189793/cbdd9d91-4cf1-4244-828e-ed1d1541a059">

