### PR TITLE
[refactor] Github actions CI 수정, CD 살리기 (#545)

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -15,3 +15,13 @@ jobs:
           cd
           sudo sh deploy.sh
         working-directory: ${{ env.working-directory }}
+
+      - name: 슬랙 알림 발송
+        uses: 8398a7/action-slack@v3
+        if: always()
+        with:
+          status: ${{ job.status }}
+          fields: repo.message,commit,author,action,workflow
+          mention: here
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/backend-dev-ci.yml
+++ b/.github/workflows/backend-dev-ci.yml
@@ -32,8 +32,11 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: 빌드 수행
-        run: ./gradlew build
-        working-directory: ${{ env.working-directory }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          build-root-directory: ${{ env.working-directory }}
+          cache-read-only: ${{ github.ref != 'refs/heads/develop-backend' }}
 
       - name: 테스트 결과 코멘트 등록
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -15,3 +15,13 @@ jobs:
           cd
           sudo sh deploy.sh
         working-directory: ${{ env.working-directory }}
+
+      - name: 슬랙 알림 발송
+        uses: 8398a7/action-slack@v3
+        if: always()
+        with:
+          status: ${{ job.status }}
+          fields: repo.message,commit,author,action,workflow
+          mention: here
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/backend-prod-ci.yml
+++ b/.github/workflows/backend-prod-ci.yml
@@ -32,8 +32,11 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: 빌드 수행
-        run: ./gradlew build
-        working-directory: ${{ env.working-directory }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          build-root-directory: ${{ env.working-directory }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: 테스트 결과 코멘트 등록
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
### 📌 관련 이슈

- closed #545 

### 📁 작업 설명

Github actions 을 통한 CI / CD 작업을 개선했습니다.

- DEV CD가 수행되지 않는 버그를 발견하고 이를 고쳤습니다. 또한 다시 이러한 일이 발생했을 때를 대비해서 슬랙 알림 기능을 추가했습니다. 관련 [문서](https://github.com/woowacourse-teams/2023-trip-draw/discussions/546) 입니다.
- CI 시간을 단축시키기 위해 caching을 도입했습니다. 관련 [문서](https://github.com/woowacourse-teams/2023-trip-draw/discussions/547) 입니다.

